### PR TITLE
Problem: InvocationOperation parses "0000" as an int

### DIFF
--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/InvocationOperation.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/InvocationOperation.java
@@ -270,7 +270,7 @@ public class InvocationOperation implements Operation {
         }
 
         // Accept any number
-        if (Number.class.isAssignableFrom(mapToBoxingClass(parameterType))) {
+        if (Number.class.isAssignableFrom(mapToBoxingClass(parameterType)) && !(argument instanceof CharSequence)) {
             Object value;
 
             try {


### PR DESCRIPTION
Solution: We know if we are given a number or a String from the client,
so we should never try to parse the given Object from a CharSequence to
a Number.

Issue: https://github.com/calabash/calabash-android/issues/677