### PR TITLE
Fix Android N text entry

### DIFF
--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/TextAction.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/actions/text/TextAction.java
@@ -36,6 +36,7 @@ public abstract class TextAction implements Action {
             // we have gotten the servedView.
             inputConnection = InfoMethodUtil.getInputConnection();
         } catch (InfoMethodUtil.UnexpectedInputMethodManagerStructureException e) {
+            e.printStackTrace();
             return Result.failedResult(e.getMessage());
         }
 

--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/utils/SystemPropertiesWrapper.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/utils/SystemPropertiesWrapper.java
@@ -1,0 +1,23 @@
+package sh.calaba.instrumentationbackend.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class SystemPropertiesWrapper {
+    public static int getInt(String key, int def) {
+        try {
+            Class<?> systemPropertiesClass = Class.forName("android.os.SystemProperties");
+            Method getInt = systemPropertiesClass.getMethod("getInt", String.class, int.class);
+
+            return (Integer) getInt.invoke(null, key, def);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Problem: Text entry on Android N

Reason: Android N changed their internal code such that a field we used
to be able to get using reflection is no longer there.

Solution: For Android N (and its betas) we try to obtain the input
connection using a different reflection route.