### PR TITLE
WindowManagerWrapper: Problem: Activity might not be initialized

### DIFF
--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/utils/WindowManagerWrapper.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/utils/WindowManagerWrapper.java
@@ -29,9 +29,19 @@ public abstract class WindowManagerWrapper {
     }
 
     private static WindowManager getWindowManagerFromContext(Context context) {
-        WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        WindowManager windowManager;
 
-        if (WindowManagerWrapper.windowManagerImplClass.isAssignableFrom(windowManager.getClass())) {
+        try {
+            windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        } catch (IllegalStateException e) {
+            // This exception will be thrown if the system service is requested before the onCreate
+            // method of the activity is called. This is fine, we should just not use the window
+            // manager of this particular activity, but use the default one.
+            windowManager = null;
+        }
+
+        if (windowManager != null
+            && WindowManagerWrapper.windowManagerImplClass.isAssignableFrom(windowManager.getClass())) {
             return windowManager;
         } else {
             return null;

--- a/server/integration-tests/src/sh/calaba/TestRunner.java
+++ b/server/integration-tests/src/sh/calaba/TestRunner.java
@@ -9,7 +9,8 @@ import org.junit.runner.notification.RunListener;
 public class TestRunner extends JUnitCore {
     private static Class<?>[] testClasses =
             {
-                    sh.calaba.json.IntentTest.class
+                    sh.calaba.json.IntentTest.class,
+                    sh.calaba.instrumentationbackend.utils.WindowManagerWrapperTest.class
             };
 
     public static void main(String... args) {

--- a/server/integration-tests/src/sh/calaba/instrumentationbackend/utils/WindowManagerWrapperTest.java
+++ b/server/integration-tests/src/sh/calaba/instrumentationbackend/utils/WindowManagerWrapperTest.java
@@ -1,0 +1,85 @@
+package sh.calaba.instrumentationbackend.utils;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.Display;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WindowManagerWrapperTest {
+    @Test
+    public void usesSystemServiceIfAvailable() {
+        MockContextAfterOnCreate mockContext = new MockContextAfterOnCreate();
+        WindowManagerWrapper.fromContext(mockContext);
+
+        assertEquals("Expected context to receive getSystemService(Context.WINDOW_SERVICE)", true, mockContext.hasRequestedSystemService());
+    }
+
+    /*
+     * See: https://github.com/calabash/calabash-android/issues/766
+     */
+    @Test
+    public void defaultsIfSystemServiceIsNotAvailable() {
+        MockContextBeforeOnCreate mockContext = new MockContextBeforeOnCreate();
+        WindowManagerWrapper.fromContext(mockContext);
+    }
+
+    private static class MockContextBeforeOnCreate extends Activity {
+        /*
+         * This is how Android behaves before onCreate has been called
+         */
+        @Override
+        public Object getSystemService(String name) {
+            throw new IllegalStateException("System services not available to Activities before onCreate()");
+        }
+    }
+
+    private static class MockContextAfterOnCreate extends Activity {
+        private boolean hasRequestedSystemService = false;
+
+        @Override
+        public Object getSystemService(String name) {
+            if (name.equals(Context.WINDOW_SERVICE)) {
+                hasRequestedSystemService = true;
+                return new MockWindowService();
+            }
+
+            throw new IllegalArgumentException("Expected name to be Context.WINDOW_SERVICE, not '" + name + "'");
+        }
+
+        public boolean hasRequestedSystemService() {
+            return hasRequestedSystemService;
+        }
+    }
+
+    private static class MockWindowService implements WindowManager {
+        @Override
+        public Display getDefaultDisplay() {
+            return null;
+        }
+
+        @Override
+        public void removeViewImmediate(View view) {
+
+        }
+
+        @Override
+        public void addView(View view, ViewGroup.LayoutParams params) {
+
+        }
+
+        @Override
+        public void updateViewLayout(View view, ViewGroup.LayoutParams params) {
+
+        }
+
+        @Override
+        public void removeView(View view) {
+
+        }
+    }
+}


### PR DESCRIPTION
Problem:
If the activity's onCreate method has not been called, getSystemService
throws an IllegalStateException.

Issue:
https://github.com/calabash/calabash-android/issues/766

Solution:
If the activity is not initialized, we should simply default to the
global window manager.

Another possible solution could be to use the previous activity.