### PR TITLE
Problem: QueryCaching: We should not cache ClassName queries

### DIFF
--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/optimization/QueryOptimizationCache.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/optimization/QueryOptimizationCache.java
@@ -5,6 +5,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import sh.calaba.instrumentationbackend.query.ast.UIQueryAST;
+import sh.calaba.instrumentationbackend.query.ast.UIQueryASTClassName;
 
 public class QueryOptimizationCache {
     private static String key;
@@ -29,6 +30,26 @@ public class QueryOptimizationCache {
         lock.lock();
 
         try {
+            // We should not cache UIQueries that use classes that have not been loaded
+            // as they might be loaded later on.
+            if (value != null) {
+                for (UIQueryAST uiQueryAST : value) {
+                    if (uiQueryAST instanceof UIQueryASTClassName) {
+                        // The query is not for a simple class name, and the qualified class is not
+                        // (yet) loaded
+                        if (((UIQueryASTClassName) uiQueryAST).qualifiedClassName == null
+                                && ((UIQueryASTClassName) uiQueryAST).simpleClassName == null) {
+                            if (key == null || key.equals(QueryOptimizationCache.key)) {
+                                QueryOptimizationCache.key = null;
+                                QueryOptimizationCache.value = null;
+                            }
+
+                            return;
+                        }
+                    }
+                }
+            }
+
             QueryOptimizationCache.key = key;
             QueryOptimizationCache.value = value;
         } finally {

--- a/server/integration-tests/src/sh/calaba/TestRunner.java
+++ b/server/integration-tests/src/sh/calaba/TestRunner.java
@@ -10,7 +10,8 @@ public class TestRunner extends JUnitCore {
     private static Class<?>[] testClasses =
             {
                     sh.calaba.json.IntentTest.class,
-                    sh.calaba.instrumentationbackend.utils.WindowManagerWrapperTest.class
+                    sh.calaba.instrumentationbackend.utils.WindowManagerWrapperTest.class,
+                    sh.calaba.instrumentationbackend.query.ast.optimization.QueryOptimizationCacheTest.class
             };
 
     public static void main(String... args) {

--- a/server/integration-tests/src/sh/calaba/instrumentationbackend/query/ast/optimization/QueryOptimizationCacheTest.java
+++ b/server/integration-tests/src/sh/calaba/instrumentationbackend/query/ast/optimization/QueryOptimizationCacheTest.java
@@ -1,0 +1,66 @@
+package sh.calaba.instrumentationbackend.query.ast.optimization;
+
+import org.junit.Test;
+import sh.calaba.instrumentationbackend.query.ast.UIQueryAST;
+import sh.calaba.instrumentationbackend.query.ast.UIQueryASTClassName;
+import sh.calaba.instrumentationbackend.query.ast.UIQueryASTWith;
+import sh.calaba.instrumentationbackend.query.ast.UIQueryVisibility;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class QueryOptimizationCacheTest {
+    private UIQueryASTClassName newUIQueryASTClassName(Class<?> clazz, Object name)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Constructor<UIQueryASTClassName> constructor = UIQueryASTClassName.class.getDeclaredConstructor(clazz);
+        constructor.setAccessible(true);
+
+        return constructor.newInstance(name);
+    }
+
+    @Test
+    public void shouldNotCacheQueriesWithUnloadedQualifiedClasses() throws Exception {
+        List<UIQueryAST> query1 = new ArrayList<UIQueryAST>();
+        query1.add(newUIQueryASTClassName(Class.class, null));
+
+        QueryOptimizationCache.cache("query1", query1);
+        assertEquals(null, QueryOptimizationCache.getCacheFor("query1"));
+
+        List<UIQueryAST> query2 = new ArrayList<UIQueryAST>();
+        query2.add(newUIQueryASTClassName(Class.class, null));
+        query2.add(new UIQueryASTWith("foo", new Object()));
+
+        QueryOptimizationCache.cache("query2", query2);
+        assertEquals(null, QueryOptimizationCache.getCacheFor("query2"));
+
+        List<UIQueryAST> query3 = new ArrayList<UIQueryAST>();
+        query3.add(new UIQueryASTWith("foo", new Object()));
+        query3.add(UIQueryVisibility.ALL);
+        query3.add(newUIQueryASTClassName(Class.class, null));
+
+        QueryOptimizationCache.cache("query3", query3);
+        assertEquals(null, QueryOptimizationCache.getCacheFor("query3"));
+    }
+
+    @Test
+    public void shouldCacheQueriesWithLoadedQualifiedClasses() throws Exception {
+        List<UIQueryAST> query4 = new ArrayList<UIQueryAST>();
+        query4.add(newUIQueryASTClassName(Class.class, Class.forName("java.lang.Object")));
+
+        QueryOptimizationCache.cache("query4", query4);
+        assertEquals(query4, QueryOptimizationCache.getCacheFor("query4"));
+    }
+
+    @Test
+    public void shouldCacheQueriesWithSimpleClasses() throws Exception {
+        List<UIQueryAST> query5 = new ArrayList<UIQueryAST>();
+        query5.add(newUIQueryASTClassName(String.class, "UnLoaded"));
+
+        QueryOptimizationCache.cache("query5", query5);
+        assertEquals(query5, QueryOptimizationCache.getCacheFor("query5"));
+    }
+}


### PR DESCRIPTION
Problem
We cache the optimization we have made of a query. E.g. a String is
cached to the optimized UIQueryAST.
    A query for a class name will NOT load the class if it is not
already loaded. If the Class is loaded later on, then it will be used.
    If we continously query for a class before it is loaded, then, after
it is loaded, the query will be cached and not recognize & update to
search for the class.

Solution
We simply stop caching a query if it has fully qualified classes in it.

Issue
https://github.com/calabash/calabash-android-server/issues/31