### PR TITLE
Get baseValue of web element's class when it is available (<svg>)

### DIFF
--- a/server/calabash-js/src/calabash.js
+++ b/server/calabash-js/src/calabash.js
@@ -87,7 +87,7 @@
         res.nodeType = NODE_TYPES[object.nodeType] || res.nodeType + ' (Unexpected)';
         res.nodeName = object.nodeName;
         res.id = object.id || '';
-        res['class'] = object.className || '';
+        res['class'] = object.getAttribute("class") || '';
         if (object.href)
         {
             res.href = object.href;

--- a/server/calabash-js/src/calabash.js
+++ b/server/calabash-js/src/calabash.js
@@ -87,11 +87,8 @@
         res.nodeType = NODE_TYPES[object.nodeType] || res.nodeType + ' (Unexpected)';
         res.nodeName = object.nodeName;
         res.id = object.id || '';
-        if (object.className.baseVal == undefined) {
-            res['class'] = object.className || '';
-        } else {
-            res['class'] = object.className.baseVal || '';
-        }
+        res['class'] = object.className.baseVal || object.className || '';
+        
         if (object.href)
         {
             res.href = object.href;

--- a/server/calabash-js/src/calabash.js
+++ b/server/calabash-js/src/calabash.js
@@ -87,7 +87,11 @@
         res.nodeType = NODE_TYPES[object.nodeType] || res.nodeType + ' (Unexpected)';
         res.nodeName = object.nodeName;
         res.id = object.id || '';
-        res['class'] = object.getAttribute("class") || '';
+        if (object.className.baseVal == undefined) {
+            res['class'] = object.className || '';
+        } else {
+            res['class'] = object.className.baseVal || '';
+        }
         if (object.href)
         {
             res.href = object.href;


### PR DESCRIPTION
Necessary because SVG elements return '[object SVGAnimatedString]'  whenever you ask for `.className`.  This behavior causes the server to return `Class: { }` whenever an svg element is queried for.

Fixes [TCFW-701](https://jira.xamarin.com/browse/TCFW-701)
