### PR TITLE
Fix exceptions when app is running with different locale than english

### DIFF
--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/Query.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/Query.java
@@ -3,6 +3,7 @@ package sh.calaba.instrumentationbackend.query;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.antlr.runtime.ANTLRStringStream;
@@ -158,7 +159,7 @@ public class Query {
 		case UIQueryParser.BEGINPRED:
 			return UIQueryASTPredicate.newPredicateFromAST(step);
 		case UIQueryParser.DIRECTION:
-			return UIQueryDirection.valueOf(step.getText().toUpperCase());			
+			return UIQueryDirection.valueOf(step.getText().toUpperCase(Locale.ENGLISH));
 			
 		default:
 			throw new InvalidUIQueryException("Unknown query: " + stepType

--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryASTPredicate.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryASTPredicate.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.*;
 
@@ -165,7 +166,7 @@ public class UIQueryASTPredicate implements UIQueryAST {
 	}
 
 	private static UIQueryASTPredicateRelation parseRelation(CommonTree rel) {
-		String relText = rel.getText().toUpperCase();
+		String relText = rel.getText().toUpperCase(Locale.ENGLISH);
 		boolean caseSensitive = true;
 		final String CASE_INSENSITIVE_SPEC = "[C]";
 		if (relText.endsWith(CASE_INSENSITIVE_SPEC)) {


### PR DESCRIPTION
**OS: Android Nogut (7.1)
Locale: Turkish 'tr'**

**QUERY:**
query("* id:'content' child android.widget.FrameLayout")

**ERROR:**
query failed because: No enum constant sh.calaba.instrumentationbackend.query.ast.UIQueryDirection.CHİLD
 (RuntimeError)

**REASON**
sh/calaba/instrumentationbackend/query/Query.java:162
step.getText().toUpperCase() yields "CHİLD" instead of "CHILD" (notice a dot above 'I' here because locale of app is not english)

Similarly, query("* {text like '* hello *'}") changes predicate to  LİKE instead of LIKE