### PR TITLE
Align targetSdkVersion in manifests and build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: android
 
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
+
 before_install:
     - sudo apt-get -qq update
     - sudo apt-get install ant
@@ -10,10 +14,10 @@ script:
 android:
   components:
     # The BuildTools version used by your project
-    - build-tools-19.1.0
+    - build-tools-22.0.1
 
     # The SDK version used to compile your project
-    - android-19
+    - android-22
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
@@ -23,7 +27,7 @@ android:
 notifications:
   email:
     recipients:
-      - joshua.moody@xamarin.com
+      - josmoo@microsoft.com
       - v-ownibl@microsoft.com
     on_success: change
     on_failure: always

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,7 +1,58 @@
 #!/usr/bin/env bash
 
+set -e
+
+source bin/log.sh
+
 CALABASH_ANDROID_SERVER_VERSION=$(cat version | tr -d "\n")
-ANDROID_API_LEVEL=19
+
+SERVER_MANIFEST="server/AndroidManifest.xml"
+BACKEND_MANIFEST="server/instrumentation-backend/AndroidManifest.xml"
+
+
+# $1 is a path to an AndroidManifest.xml
+# $2 is the manifest key to inspect
+function sdk_version_from_manifest {
+  if [ ! -e "${1}" ]; then
+    error "Expected "${1}" to exist."
+    exit 1
+  fi
+
+  local version=$(
+    perl -lne "print $& if /${2}=\"\d+\"/" "${1}" | cut -d= -f2 | tr -d \"
+  )
+
+  if [ "${version}" = "" ]; then
+    error "Could not find key/value pair in file"
+    error " key: '${2}'"
+    error "file: ${1}"
+    exit 1
+  fi
+
+  echo -n $version
+}
+
+# $1 is a path to an AndroidManifest.xml
+function target_sdk {
+  if [ ! -e "${1}" ]; then
+    error "Expected "${1}" to exist."
+    exit 1
+  fi
+
+  local version=$(sdk_version_from_manifest "${1}" "android:targetSdkVersion")
+  echo -n $version
+}
+
+# $1 is a path to an AndroidManifest.xml
+function min_sdk {
+  if [ ! -e "${1}" ]; then
+    error "Expected "${1}" to exist."
+    exit 1
+  fi
+
+  local version=$(sdk_version_from_manifest "${1}" "android:minSdkVersion")
+  echo -n $version
+}
 
 function verify_tool {
   command -v $1 > /dev/null
@@ -11,16 +62,45 @@ function verify_tool {
   fi
 }
 
+banner "Inspecting Manifest Versions"
+
+SERVER_API_LEVEL=$(target_sdk "${SERVER_MANIFEST}")
+BACKEND_API_LEVEL=$(target_sdk "${BACKEND_MANIFEST}")
+
+if [ "${SERVER_API_LEVEL}" != "${BACKEND_API_LEVEL}" ]; then
+  error "Expected android:targetSdkVersion to be the same in these files:"
+  echo -e "* ${BACKEND_API_LEVEL}\t<= ${BACKEND_MANIFEST}"
+  echo -e "* ${SERVER_API_LEVEL}\t<= x${SERVER_MANIFEST}"
+  exit 1
+fi
+
+ANDROID_API_LEVEL=$SERVER_API_LEVEL
+
+SERVER_MIN_VERSION=$(min_sdk "${SERVER_MANIFEST}")
+BACKEND_MIN_VERSION=$(min_sdk "${BACKEND_MANIFEST}")
+
+if [ "${SERVER_MIN_VERSION}" != "${BACKEND_MIN_VERSION}" ]; then
+  error "Expected android:minSdkVersion to be the same in these files:"
+  error "* ${BACKEND_MIN_VERSION}\t<= ${BACKEND_MANIFEST}"
+  error "* ${SERVER_MIN_VERSION}\t<= ${SERVER_MANIFEST}"
+  exit 1
+fi
+
+info "android:targetSdkVersion=${SERVER_API_LEVEL}"
+info "   android:minSdkVersion=${SERVER_MIN_VERSION}"
+
+banner "Expecting ANDROID env variables"
+
 cd server
 
 verify_tool ant
 
 if [ -z ${ANDROID_TOOLS_DIR+x} ]; then
   if [ -z ${ANDROID_HOME+x} ]; then
-    echo "\$ANDROID_HOME not set. Please specify an android home directory and \
+    error "\$ANDROID_HOME not set. Please specify an android home directory and \
     rerun:"
-    echo "ANDROID_HOME=/path/to/android_home ./build.sh"
-    exit 2
+    error "ANDROID_HOME=/path/to/android_home ./build.sh"
+    exit 1
   fi
 
   if [ -d "${ANDROID_HOME}/build-tools" ]; then
@@ -29,19 +109,30 @@ if [ -z ${ANDROID_TOOLS_DIR+x} ]; then
   elif [ -d "${ANDROID_HOME}/platform-tools" ]; then
     export ANDROID_TOOLS_DIR="${ANDROID_HOME}/platform-tools"
   else
-    echo "Unable to find android build tools in ${ANDROID_HOME}"
-    echo "For full instuctions see: https://github.com/calabash/calabash-androi\
+    error "Unable to find android build tools in ${ANDROID_HOME}"
+    error "For full instuctions see: https://github.com/calabash/calabash-androi\
     d/wiki/Building-calabash-android"
-    exit 4
+    exit 1
   fi
 elif [ ! -d "${ANDROID_TOOLS_DIR}" ]; then
-  echo "Tools dir '${ANDROID_TOOLS_DIR}' does not exist"
-  echo "Please specify a valid tools dir and try again:"
-  echo "ANDROID_TOOLS_DIR=/path/to/tools_dir ./build.sh"
-  exit 3
+  error "Tools dir '${ANDROID_TOOLS_DIR}' does not exist"
+  error "Please specify a valid tools dir and try again:"
+  error "ANDROID_TOOLS_DIR=/path/to/tools_dir ./build.sh"
+  exit 1
 fi
 
 CMD="ant clean package -debug -Dtools.dir=${ANDROID_TOOLS_DIR}\
   -Dandroid.api.level=${ANDROID_API_LEVEL} -Dversion=${CALABASH_ANDROID_SERVER_VERSION}"
-echo "${CMD}"
+
+shell "${CMD}"
+
 $CMD
+
+banner "Done"
+
+info "Built server ${CALABASH_ANDROID_SERVER_VERSION} with command:"
+
+shell "${CMD}"
+
+info "android:targetSdkVersion=${SERVER_API_LEVEL}"
+info "   android:minSdkVersion=${SERVER_MIN_VERSION}"

--- a/bin/log.sh
+++ b/bin/log.sh
@@ -8,17 +8,25 @@
 
 function info {
   if [ "${TERM}" = "dumb" ]; then
-    echo "INFO: $1"
+    echo -e "INFO: $1"
   else
-    echo "$(tput setaf 2)INFO: $1$(tput sgr0)"
+    echo -e "$(tput setaf 2)INFO: $1$(tput sgr0)"
+  fi
+}
+
+function shell {
+  if [ "${TERM}" = "dumb" ]; then
+    echo -e "SHELL: $1"
+  else
+    echo -e "$(tput setaf 6)SHELL: $1$(tput sgr0)"
   fi
 }
 
 function error {
   if [ "${TERM}" = "dumb" ]; then
-    echo "ERROR: $1"
+    echo -e "ERROR: $1"
   else
-    echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
+    echo -e "$(tput setaf 1)ERROR: $1$(tput sgr0)"
   fi
 }
 

--- a/server/AndroidManifest.xml
+++ b/server/AndroidManifest.xml
@@ -51,8 +51,8 @@
         android:noHistory="true"
         android:excludeFromRecents="true"/>
     </application>
-    <uses-sdk android:minSdkVersion="4"
-        android:targetSdkVersion="21"/>
+    <uses-sdk android:minSdkVersion="8"
+        android:targetSdkVersion="22"/>
     <instrumentation android:targetPackage="#targetPackage#" android:name="sh.calaba.instrumentationbackend.CalabashInstrumentationTestRunner" />
     <instrumentation android:targetPackage="#targetPackage#" android:name="sh.calaba.instrumentationbackend.ClearAppData" />
     <instrumentation android:targetPackage="#targetPackage#" android:name="sh.calaba.instrumentationbackend.ClearAppData2" />

--- a/server/build.xml
+++ b/server/build.xml
@@ -18,7 +18,7 @@
 
     <property name="dx" location="${tools.dir}/dx${bat}" />
     <property name="aapt" location="${tools.dir}/aapt" />
-    
+
     <property name="android.lib" location="${env.ANDROID_HOME}/platforms/android-${android.api.level}/android.jar"/>
     <path id="android.antlibs">
         <pathelement path="${env.ANDROID_HOME}/tools/lib/ant-tasks.jar" />


### PR DESCRIPTION
### Motivation

Aligns the `targetSdkVersion` and `minSdkVersion` across these three sources:

* server/AndroidManfiest.xml
* server/instrumentation-backend/AndroidManfest.xml
* bin/build.sh 

The build script now reads the two manifests and errors out if the two version keys are not equal.