### PR TITLE
Fix for resource 0xffff... missing error

### DIFF
--- a/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryASTWith.java
+++ b/server/instrumentation-backend/src/sh/calaba/instrumentationbackend/query/ast/UIQueryASTWith.java
@@ -234,6 +234,10 @@ public class UIQueryASTWith implements UIQueryAST {
 			return false;
 		}
 		View view = (View) o;
+		if (view.getId() == -1)
+		{
+			return false;
+		}
 		String expected = (String) expectedValue;
 		String id = UIQueryUtils.getId(view);
 		return (id != null && id.equals(expected));


### PR DESCRIPTION
### Motivation
Getting reports of Android O being much slower than other versions of android - I suspect that it's related to this error message (as there are a ton of them) but regardless - I want to stop filling logs with the error if we can help it.

It's more than possible that this will mask a larger problem - but we might be able to use what we learn here to diagnose the root cause later. For now, I just want to see if stopping logging that error (and the code which causes the error) makes the tests run any faster.

### Notes
I may need some help increasing the version number and doing everything necessary to get this in a UITest release. I'll try and work it out first though :)