### PR TITLE
Changed build.sh to prevent silent build failings.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -55,11 +55,10 @@ function min_sdk {
 }
 
 function verify_tool {
-  command -v $1 > /dev/null
-  if [ $? -ne 0 ]; then
+  hash "${1}" 2>/dev/null || {
     echo "Error: Command '${1}' not found"
     exit 1
-  fi
+  }
 }
 
 banner "Inspecting Manifest Versions"


### PR DESCRIPTION
**Problem:** silent build failings if ant is not installed.

**Root-cause:**
The build script works in "Exit immediately" mode `set -e`
With previous verify_tool implementation if 'ant' is not installed
```
verify_tool ant:
command -v $1 > /dev/null
```
exited without any notification/errors.
You will see only
```
######## Inspecting Manifest Versions ########

-e INFO: android:targetSdkVersion=-n -n 22
-e INFO:    android:minSdkVersion=-n -n 8

######## Expecting ANDROID env variables ########
```

**Changes:** Changed implementation of verify_tool to prevent silent build failings.