### PR TITLE
remove make complete (dark gray list)

### DIFF
--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
@@ -142,7 +142,7 @@ public class FakeGPSLocation implements Action {
             location.setLongitude(longitude);
             location.setAccuracy(1);
             location.setTime(System.currentTimeMillis());
-            if Build.VERSION.SDK_INT >= 17 {
+            if Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN {
                 location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
             }
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
@@ -142,16 +142,8 @@ public class FakeGPSLocation implements Action {
             location.setLongitude(longitude);
             location.setAccuracy(1);
             location.setTime(System.currentTimeMillis());
-
-            try {
-                Method makeComplete = Location.class.getMethod("makeComplete");
-                if (makeComplete != null) {
-                    makeComplete.invoke(location);
-                }
-            } catch (Exception e) {
-                //Method only available in Jelly Bean
-            }
-
+            location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
+            
             locationManager.setTestProviderLocation(locationProvider, location);
         }
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
@@ -142,8 +142,10 @@ public class FakeGPSLocation implements Action {
             location.setLongitude(longitude);
             location.setAccuracy(1);
             location.setTime(System.currentTimeMillis());
-            location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
-            
+            if Build.VERSION.SDK_INT >= 17 {
+                location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
+            }
+
             locationManager.setTestProviderLocation(locationProvider, location);
         }
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
@@ -2,6 +2,7 @@ package sh.calaba.instrumentationbackend.actions.location;
 
 
 import android.os.Build;
+import android.os.SystemClock;
 import sh.calaba.instrumentationbackend.InstrumentationBackend;
 import sh.calaba.instrumentationbackend.Result;
 import sh.calaba.instrumentationbackend.actions.Action;
@@ -142,10 +143,9 @@ public class FakeGPSLocation implements Action {
             location.setLongitude(longitude);
             location.setAccuracy(1);
             location.setTime(System.currentTimeMillis());
-            if Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                 location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
             }
-
             locationManager.setTestProviderLocation(locationProvider, location);
         }
 


### PR DESCRIPTION
Remove the use of makeComplete as it is now (dark) gray listed (at least on some builds...) Instead of calling makeComplete, we makes sure that location is complete by setting the fields that are tested by `isComplete` https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/location/java/android/location/Location.java#973