### PR TITLE
Implemented logic to handle webview input

### DIFF
--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -38,7 +38,7 @@ public class DeleteSurroundingText extends TextAction {
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         int beforeLength, afterLength;
 
-        if (Build.VERSION.SDK_INT >= 27 && servedView instanceof WebView) {
+        if (servedView instanceof WebView) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -15,49 +15,6 @@ public class DeleteSurroundingText extends TextAction {
 
     private int argBeforeLength, argAfterLength;
 
-    private static String webViewDeleteScript =
-            "var activeElement = document.activeElement;\n" +
-            "var tagName = activeElement.tagName.toLowerCase();\n" +
-            "var from = 0;\n" +
-            "var to = 0;\n" +
-            "if (tagName === 'input' || tagName === 'textarea') {\n" +
-            "    from = activeElement.selectionStart;\n" +
-            "    to = activeElement.selectionEnd;\n" +
-            "} else if (window.getSelection) {\n" +
-            "    var sel = window.getSelection();\n" +
-            "    if (sel.rangeCount) {\n" +
-            "        var range = sel.getRangeAt(0);\n" +
-            "        from = range.startOffset;\n" +
-            "        to = range.endOffset;\n" +
-            "    }\n" +
-            "}\n" +
-            "var argBeforeLength = '%1$s';\n" +
-            "var argAfterLength = '%2$s';\n" +
-            "var beforeLength, afterLength;\n" +
-            "var value;\n" +
-            "if (tagName === 'input' || tagName === 'textarea') {\n" +
-            "    value = activeElement.value;\n" +
-            "} else {\n" +
-            "    value = activeElement.innerHTML;\n" +
-            "}\n" +
-            "var textLength = value.length;\n" +
-            "if (argBeforeLength < 0) {\n" +
-            "    beforeLength = textLength + argBeforeLength + 1;\n" +
-            "} else {\n" +
-            "    beforeLength = argBeforeLength;\n" +
-            "}\n" +
-            "if (argAfterLength < 0) {\n" +
-            "    afterLength = textLength + argAfterLength + 1;\n" +
-            "} else {\n" +
-            "    afterLength = argAfterLength;\n" +
-            "}\n" +
-            "var resultValue = value.substring(0, from - beforeLength) + value.substring(to + afterLength, value.length);\n" +
-            "if (tagName === 'input' || tagName === 'textarea') {\n" +
-            "    activeElement.value = resultValue;\n" +
-            "} else {\n" +
-            "    activeElement.innerHTML = resultValue;\n" +
-            "}";
-
     @Override
     protected void parseArguments(String... args) throws IllegalArgumentException {
         if (args.length != 2) {
@@ -79,7 +36,6 @@ public class DeleteSurroundingText extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        int textLength;
         int beforeLength, afterLength;
 
         if (Build.VERSION.SDK_INT >= 27 && servedView instanceof WebView) {
@@ -92,7 +48,7 @@ public class DeleteSurroundingText extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    webView.evaluateJavascript(String.format(webViewDeleteScript, argBeforeLength, argAfterLength), null);
+                    webView.evaluateJavascript(String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength), null);
                 }
             });
 
@@ -104,7 +60,7 @@ public class DeleteSurroundingText extends TextAction {
         }
 
         // Find length of non-formatted text
-        textLength = InfoMethodUtil.getTextLength(inputConnection);
+        int textLength = InfoMethodUtil.getTextLength(inputConnection);
 
         if (argBeforeLength < 0) {
             beforeLength = textLength + argBeforeLength + 1;

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -5,6 +5,8 @@ import android.text.Editable;
 import android.text.Selection;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
 
 import sh.calaba.instrumentationbackend.Result;
 
@@ -12,6 +14,49 @@ public class DeleteSurroundingText extends TextAction {
     private static final String USAGE = "This action takes 2 arguments:\n([int] beforeLength, [int] afterLength)";
 
     private int argBeforeLength, argAfterLength;
+
+    private static String webViewDeleteScript =
+            "var activeElement = document.activeElement;\n" +
+            "var tagName = activeElement.tagName.toLowerCase();\n" +
+            "var from = 0;\n" +
+            "var to = 0;\n" +
+            "if (tagName === 'input' || tagName === 'textarea') {\n" +
+            "    from = activeElement.selectionStart;\n" +
+            "    to = activeElement.selectionEnd;\n" +
+            "} else if (window.getSelection) {\n" +
+            "    var sel = window.getSelection();\n" +
+            "    if (sel.rangeCount) {\n" +
+            "        var range = sel.getRangeAt(0);\n" +
+            "        from = range.startOffset;\n" +
+            "        to = range.endOffset;\n" +
+            "    }\n" +
+            "}\n" +
+            "var argBeforeLength = '%1$s';\n" +
+            "var argAfterLength = '%2$s';\n" +
+            "var beforeLength, afterLength;\n" +
+            "var value;\n" +
+            "if (tagName === 'input' || tagName === 'textarea') {\n" +
+            "    value = activeElement.value;\n" +
+            "} else {\n" +
+            "    value = activeElement.innerHTML;\n" +
+            "}\n" +
+            "var textLength = value.length;\n" +
+            "if (argBeforeLength < 0) {\n" +
+            "    beforeLength = textLength + argBeforeLength + 1;\n" +
+            "} else {\n" +
+            "    beforeLength = argBeforeLength;\n" +
+            "}\n" +
+            "if (argAfterLength < 0) {\n" +
+            "    afterLength = textLength + argAfterLength + 1;\n" +
+            "} else {\n" +
+            "    afterLength = argAfterLength;\n" +
+            "}\n" +
+            "var resultValue = value.substring(0, from - beforeLength) + value.substring(to + afterLength, value.length);\n" +
+            "if (tagName === 'input' || tagName === 'textarea') {\n" +
+            "    activeElement.value = resultValue;\n" +
+            "} else {\n" +
+            "    activeElement.innerHTML = resultValue;\n" +
+            "}";
 
     @Override
     protected void parseArguments(String... args) throws IllegalArgumentException {
@@ -34,9 +79,32 @@ public class DeleteSurroundingText extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        // Find length of non-formatted text
-        int textLength = InfoMethodUtil.getTextLength(inputConnection);
+        int textLength;
         int beforeLength, afterLength;
+
+        if (Build.VERSION.SDK_INT >= 27 && servedView instanceof WebView) {
+            WebView webView = (WebView) servedView;
+
+            // Execute JS on the UI thread
+            webView.post(new Runnable() {
+                @Override
+                public void run() {
+                    WebSettings webSettings = webView.getSettings();
+                    webSettings.setJavaScriptEnabled(true);
+
+                    webView.evaluateJavascript(String.format(webViewDeleteScript, argBeforeLength, argAfterLength), null);
+                }
+            });
+
+            return Result.successResult();
+        }
+
+        if (inputConnection == null) {
+            Result.failedResult(getNoFocusedViewMessage());
+        }
+
+        // Find length of non-formatted text
+        textLength = InfoMethodUtil.getTextLength(inputConnection);
 
         if (argBeforeLength < 0) {
             beforeLength = textLength + argBeforeLength + 1;

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -31,32 +31,15 @@ public class DeleteSurroundingText extends TextAction {
 
     @Override
     protected String getNoFocusedViewMessage() {
-        return "Unable to delete surrounding text, no element has focus";
+        return "Unable to delete surrounding text. Make sure that the input element has focus.";
     }
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         int beforeLength, afterLength;
 
-        if (servedView instanceof WebView && Build.VERSION.SDK_INT > 27) {
-            WebView webView = (WebView) servedView;
-
-            // Execute JS on the UI thread
-            webView.post(new Runnable() {
-                @Override
-                public void run() {
-                    WebSettings webSettings = webView.getSettings();
-                    webSettings.setJavaScriptEnabled(true);
-
-                    webView.evaluateJavascript(String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength), null);
-                }
-            });
-
-            return Result.successResult();
-        }
-
-        if (inputConnection == null) {
-            Result.failedResult(getNoFocusedViewMessage());
+        if (requiresWebViewInput(servedView)) {
+            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength);
         }
 
         // Find length of non-formatted text

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -48,11 +48,7 @@ public class DeleteSurroundingText extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        webView.evaluateJavascript(String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength), null);
-                    } else {
-                        webView.loadUrl("javascript:" + String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength));
-                    }
+                    webView.evaluateJavascript(String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength), null);
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -1,14 +1,14 @@
 package sh.calaba.instrumentationbackend.actions.text;
 
 import android.os.Build;
-import android.text.Editable;
-import android.text.Selection;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
-import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.query.CompletedFuture;
+
+import java.util.concurrent.Future;
 
 public class DeleteSurroundingText extends TextAction {
     private static final String USAGE = "This action takes 2 arguments:\n([int] beforeLength, [int] afterLength)";
@@ -35,7 +35,7 @@ public class DeleteSurroundingText extends TextAction {
     }
 
     @Override
-    protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+    protected Future<Result> executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         int beforeLength, afterLength;
 
         if (requiresWebViewInput(servedView)) {
@@ -64,7 +64,7 @@ public class DeleteSurroundingText extends TextAction {
 
         inputConnection.deleteSurroundingText(beforeLength, afterLength);
 
-        return Result.successResult();
+        return new CompletedFuture<>(Result.successResult());
     }
 
     @Override

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -39,7 +39,7 @@ public class DeleteSurroundingText extends TextAction {
         int beforeLength, afterLength;
 
         if (requiresWebViewInput(servedView)) {
-            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength);
+            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.deleteTextScript(argBeforeLength, argAfterLength));
         }
 
         // Find length of non-formatted text

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -38,7 +38,7 @@ public class DeleteSurroundingText extends TextAction {
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         int beforeLength, afterLength;
 
-        if (servedView instanceof WebView) {
+        if (servedView instanceof WebView && Build.VERSION.SDK_INT >= 27) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread
@@ -48,7 +48,11 @@ public class DeleteSurroundingText extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    webView.evaluateJavascript(String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength), null);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                        webView.evaluateJavascript(String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength), null);
+                    } else {
+                        webView.loadUrl("javascript:" + String.format(WebViewInputScripts.DeleteScript, argBeforeLength, argAfterLength));
+                    }
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/DeleteSurroundingText.java
@@ -38,7 +38,7 @@ public class DeleteSurroundingText extends TextAction {
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         int beforeLength, afterLength;
 
-        if (servedView instanceof WebView && Build.VERSION.SDK_INT >= 27) {
+        if (servedView instanceof WebView && Build.VERSION.SDK_INT > 27) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/InfoMethodUtil.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/InfoMethodUtil.java
@@ -2,14 +2,12 @@ package sh.calaba.instrumentationbackend.actions.text;
 
 import android.content.Context;
 import android.os.Build;
-import android.text.InputType;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 
 import sh.calaba.instrumentationbackend.InstrumentationBackend;
-import sh.calaba.instrumentationbackend.utils.SystemPropertiesWrapper;
 
 import java.lang.reflect.Field;
 
@@ -31,43 +29,12 @@ public class InfoMethodUtil {
     }
 
     public static InputConnection getInputConnection() throws UnexpectedInputMethodManagerStructureException {
-        Context context = InstrumentationBackend.instrumentation.getTargetContext();
-
         try {
-            if (Build.VERSION.SDK_INT > 27) {
-                EditorInfo info = new EditorInfo();
-                InputConnection inputConnection = getServedView().onCreateInputConnection(info);
+            EditorInfo info = new EditorInfo();
+            InputConnection inputConnection = getServedView().onCreateInputConnection(info);
 
-                return inputConnection;
-            }
-
-            InputMethodManager inputMethodManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-
-            int previewSdkInt = SystemPropertiesWrapper.getInt("ro.build.version.preview_sdk", 0);
-
-            // We support Android N, which has SDK_INT of 22, but PREVIEW_SDK_INT >= 3
-            if (Build.VERSION.SDK_INT > 23
-                    || (Build.VERSION.SDK_INT == 23 && previewSdkInt >= 3)) { // Android N changed its internal structure
-                Field servedInputConnectionWrapperField = inputMethodManager.getClass().getDeclaredField("mServedInputConnectionWrapper");
-                servedInputConnectionWrapperField.setAccessible(true);
-                Object servedInputConnectionWrapper = servedInputConnectionWrapperField.get(inputMethodManager);
-
-                Class iInputConnectionWrapperClass = Class.forName("com.android.internal.view.IInputConnectionWrapper");
-                Field inputConnectionField = iInputConnectionWrapperClass.getDeclaredField("mInputConnection");
-                inputConnectionField.setAccessible(true);
-
-                return (InputConnection) inputConnectionField.get(servedInputConnectionWrapper);
-            } else {
-                Field servedInputConnectionField = InputMethodManager.class.getDeclaredField("mServedInputConnection");
-                servedInputConnectionField.setAccessible(true);
-
-                return (InputConnection) servedInputConnectionField.get(inputMethodManager);
-            }
-        } catch (IllegalAccessException e) {
-            throw new UnexpectedInputMethodManagerStructureException(e);
-        } catch (NoSuchFieldException e) {
-            throw new UnexpectedInputMethodManagerStructureException(e);
-        } catch (ClassNotFoundException e) {
+            return inputConnection;
+        } catch (Exception e) {
             throw new UnexpectedInputMethodManagerStructureException(e);
         }
     }

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/InfoMethodUtil.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/InfoMethodUtil.java
@@ -2,7 +2,9 @@ package sh.calaba.instrumentationbackend.actions.text;
 
 import android.content.Context;
 import android.os.Build;
+import android.text.InputType;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 
@@ -32,6 +34,13 @@ public class InfoMethodUtil {
         Context context = InstrumentationBackend.instrumentation.getTargetContext();
 
         try {
+            if (Build.VERSION.SDK_INT >= 27) {
+                EditorInfo info = new EditorInfo();
+                InputConnection inputConnection = getServedView().onCreateInputConnection(info);
+
+                return inputConnection;
+            }
+
             InputMethodManager inputMethodManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
 
             int previewSdkInt = SystemPropertiesWrapper.getInt("ro.build.version.preview_sdk", 0);

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/InfoMethodUtil.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/InfoMethodUtil.java
@@ -34,7 +34,7 @@ public class InfoMethodUtil {
         Context context = InstrumentationBackend.instrumentation.getTargetContext();
 
         try {
-            if (Build.VERSION.SDK_INT >= 27) {
+            if (Build.VERSION.SDK_INT > 27) {
                 EditorInfo info = new EditorInfo();
                 InputConnection inputConnection = getServedView().onCreateInputConnection(info);
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -15,18 +15,6 @@ import sh.calaba.instrumentationbackend.Result;
 public class KeyboardEnterText extends TextAction {
     private String textToEnter;
 
-    private static String webViewInputScript =
-              "var activeElement = document.activeElement;\n" +
-              "var tagName = activeElement.tagName.toLowerCase();\n" +
-              "if (tagName === 'input' || tagName === 'textarea') {\n" +
-              "    activeElement.value = '%1$s';\n" +
-              "} else if (activeElement.contentEditable === 'true') {\n" +
-              "    activeElement.innerHTML = '%1$s';\n" +
-              "} else {\n" +
-              "    activeElement.value = '%1$s';\n" +
-              "    activeElement.innerHTML = '%1$s';\n" +
-              "}\n";
-
     @Override
     protected void parseArguments(String... args) throws IllegalArgumentException {
         if (args.length != 1) {
@@ -53,7 +41,7 @@ public class KeyboardEnterText extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    webView.evaluateJavascript(String.format(webViewInputScript, textToEnter), null);
+                    webView.evaluateJavascript(String.format(WebViewInputScripts.InputScript, textToEnter), null);
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -41,11 +41,7 @@ public class KeyboardEnterText extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        webView.evaluateJavascript(String.format(WebViewInputScripts.InputScript, textToEnter), null);
-                    } else {
-                        webView.loadUrl("javascript:" + String.format(WebViewInputScripts.InputScript, textToEnter));
-                    }
+                    webView.evaluateJavascript(String.format(WebViewInputScripts.InputScript, textToEnter), null);
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -26,30 +26,13 @@ public class KeyboardEnterText extends TextAction {
 
     @Override
     protected String getNoFocusedViewMessage() {
-        return "Could not enter text. No element has focus.";
+        return "Could not enter text. Make sure that the input element has focus.";
     }
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (servedView instanceof WebView && Build.VERSION.SDK_INT > 27) {
-            WebView webView = (WebView) servedView;
-
-            // Execute JS on the UI thread
-            webView.post(new Runnable() {
-                @Override
-                public void run() {
-                    WebSettings webSettings = webView.getSettings();
-                    webSettings.setJavaScriptEnabled(true);
-
-                    webView.evaluateJavascript(String.format(WebViewInputScripts.InputScript, textToEnter), null);
-                }
-            });
-
-            return Result.successResult();
-        }
-
-        if (inputConnection == null) {
-            Result.failedResult(getNoFocusedViewMessage());
+        if (requiresWebViewInput(servedView)) {
+            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.InputScript, textToEnter.replaceAll("\'", "\\\\x27"));
         }
 
         int start = InfoMethodUtil.getSelectionStart(inputConnection);

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -1,16 +1,15 @@
 package sh.calaba.instrumentationbackend.actions.text;
 
 import android.os.Build;
-import android.text.Editable;
-import android.text.Selection;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
-import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import java.lang.Character;
+import java.util.concurrent.Future;
 
 import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.query.CompletedFuture;
 
 public class KeyboardEnterText extends TextAction {
     private String textToEnter;
@@ -30,7 +29,7 @@ public class KeyboardEnterText extends TextAction {
     }
 
     @Override
-    protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+    protected Future<Result> executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         if (requiresWebViewInput(servedView)) {
             return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.enterTextScript(textToEnter));
         }
@@ -50,7 +49,7 @@ public class KeyboardEnterText extends TextAction {
             inputConnection.setComposingRegion(start, end);
         }
 
-        return Result.successResult();
+        return new CompletedFuture<>(Result.successResult());
     }
 
     @Override

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -31,7 +31,7 @@ public class KeyboardEnterText extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (servedView instanceof WebView && Build.VERSION.SDK_INT >= 27) {
+        if (servedView instanceof WebView && Build.VERSION.SDK_INT > 27) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -31,7 +31,7 @@ public class KeyboardEnterText extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (servedView instanceof WebView) {
+        if (servedView instanceof WebView && Build.VERSION.SDK_INT >= 27) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread
@@ -41,7 +41,11 @@ public class KeyboardEnterText extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    webView.evaluateJavascript(String.format(WebViewInputScripts.InputScript, textToEnter), null);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                        webView.evaluateJavascript(String.format(WebViewInputScripts.InputScript, textToEnter), null);
+                    } else {
+                        webView.loadUrl("javascript:" + String.format(WebViewInputScripts.InputScript, textToEnter));
+                    }
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -31,7 +31,7 @@ public class KeyboardEnterText extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (Build.VERSION.SDK_INT >= 27 && servedView instanceof WebView) {
+        if (servedView instanceof WebView) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardEnterText.java
@@ -32,7 +32,7 @@ public class KeyboardEnterText extends TextAction {
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         if (requiresWebViewInput(servedView)) {
-            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.InputScript, textToEnter.replaceAll("\'", "\\\\x27"));
+            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.enterTextScript(textToEnter));
         }
 
         int start = InfoMethodUtil.getSelectionStart(inputConnection);

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardKeyEvent.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardKeyEvent.java
@@ -31,15 +31,11 @@ public class KeyboardKeyEvent extends TextAction {
 
     @Override
     protected String getNoFocusedViewMessage() {
-        return "Unable to perform keyboard key event, no element has focus";
+        return "Unable to perform keyboard key event. Make sure that the input element has focus.";
     }
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (inputConnection == null) {
-            Result.failedResult(getNoFocusedViewMessage());
-        }
-
         inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
         inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keyCode));
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardKeyEvent.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardKeyEvent.java
@@ -36,6 +36,10 @@ public class KeyboardKeyEvent extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+        if (inputConnection == null) {
+            Result.failedResult(getNoFocusedViewMessage());
+        }
+
         inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
         inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keyCode));
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardKeyEvent.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/KeyboardKeyEvent.java
@@ -6,6 +6,9 @@ import android.view.inputmethod.InputConnection;
 
 import sh.calaba.instrumentationbackend.Result;
 import sh.calaba.instrumentationbackend.actions.softkey.KeyUtil;
+import sh.calaba.instrumentationbackend.query.CompletedFuture;
+
+import java.util.concurrent.Future;
 
 public class KeyboardKeyEvent extends TextAction {
     private Integer keyCode;
@@ -35,11 +38,11 @@ public class KeyboardKeyEvent extends TextAction {
     }
 
     @Override
-    protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+    protected Future<Result> executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
         inputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keyCode));
 
-        return Result.successResult();
+        return new CompletedFuture<>(Result.successResult());
     }
 
     @Override

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/PressUserActionButton.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/PressUserActionButton.java
@@ -43,7 +43,7 @@ public class PressUserActionButton extends TextAction {
 
     @Override
     protected String getNoFocusedViewMessage() {
-        return "Could not press user action button, not element has focus.";
+        return "Could not press user action button. Make sure that the input element has focus.";
     }
 
     @Override

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/PressUserActionButton.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/PressUserActionButton.java
@@ -9,8 +9,10 @@ import android.widget.TextView;
 import java.lang.Integer;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.concurrent.Future;
 
 import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.query.CompletedFuture;
 
 public class PressUserActionButton extends TextAction {
     private static Map<String,Integer> actionCodeMap;
@@ -47,7 +49,7 @@ public class PressUserActionButton extends TextAction {
     }
 
     @Override
-    protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+    protected Future<Result> executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         final Integer imeActionCode;
 
         if (imeActionCodeArgument != null) {
@@ -64,7 +66,7 @@ public class PressUserActionButton extends TextAction {
         } else {
             inputConnection.performEditorAction(imeActionCode);
 
-            return Result.successResult();
+            return new CompletedFuture<>(Result.successResult());
         }
     }
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
@@ -4,8 +4,6 @@ import android.os.Build;
 import android.text.Editable;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
 
 import sh.calaba.instrumentationbackend.Result;
 
@@ -35,23 +33,6 @@ public class SetComposingRegion extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (servedView instanceof WebView) {
-            WebView webView = (WebView) servedView;
-
-            // Execute JS on the UI thread
-            webView.post(new Runnable() {
-                @Override
-                public void run() {
-                    WebSettings webSettings = webView.getSettings();
-                    webSettings.setJavaScriptEnabled(true);
-
-                    webView.evaluateJavascript(String.format(WebViewInputScripts.SelectScript, argFrom, argTo), null);
-                }
-            });
-
-            return Result.successResult();
-        }
-
         if (inputConnection == null) {
             Result.failedResult(getNoFocusedViewMessage());
         }

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
@@ -35,7 +35,7 @@ public class SetComposingRegion extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (Build.VERSION.SDK_INT >= 27 && servedView instanceof WebView) {
+        if (servedView instanceof WebView) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
@@ -1,11 +1,13 @@
 package sh.calaba.instrumentationbackend.actions.text;
 
 import android.os.Build;
-import android.text.Editable;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
 
 import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.query.CompletedFuture;
+
+import java.util.concurrent.Future;
 
 public class SetComposingRegion extends TextAction {
     private static final String USAGE = "This action takes 2 arguments:\n([int] start, [int] end)";
@@ -32,9 +34,9 @@ public class SetComposingRegion extends TextAction {
     }
 
     @Override
-    protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+    protected Future<Result> executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         if (Build.VERSION.SDK_INT < 9) {
-            return Result.failedResult("Cannot set composing region on Android < 9");
+            return new CompletedFuture<>(Result.failedResult("Cannot set composing region on Android < 9"));
         }
 
         // Find length of non-formatted text
@@ -55,7 +57,7 @@ public class SetComposingRegion extends TextAction {
 
         inputConnection.setComposingRegion(from, to);
 
-        return Result.successResult();
+        return new CompletedFuture<>(Result.successResult());
     }
 
     @Override

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetComposingRegion.java
@@ -28,15 +28,11 @@ public class SetComposingRegion extends TextAction {
 
     @Override
     protected String getNoFocusedViewMessage() {
-        return "Unable to set composing region, no element has focus";
+        return "Unable to set composing region. Make sure that the input element has focus.";
     }
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (inputConnection == null) {
-            Result.failedResult(getNoFocusedViewMessage());
-        }
-
         if (Build.VERSION.SDK_INT < 9) {
             return Result.failedResult("Cannot set composing region on Android < 9");
         }

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -1,6 +1,5 @@
 package sh.calaba.instrumentationbackend.actions.text;
 
-import android.os.Build;
 import android.text.Editable;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
@@ -35,7 +34,7 @@ public class SetSelection extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (Build.VERSION.SDK_INT >= 27 && servedView instanceof WebView) {
+        if (servedView instanceof WebView) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -45,11 +45,7 @@ public class SetSelection extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        webView.evaluateJavascript(String.format(WebViewInputScripts.SelectScript, argFrom, argTo), null);
-                    } else {
-                        webView.loadUrl("javascript:" + String.format(WebViewInputScripts.SelectScript, argFrom, argTo));
-                    }
+                    webView.evaluateJavascript(String.format(WebViewInputScripts.SelectScript, argFrom, argTo), null);
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -1,5 +1,6 @@
 package sh.calaba.instrumentationbackend.actions.text;
 
+import android.os.Build;
 import android.text.Editable;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
@@ -34,7 +35,7 @@ public class SetSelection extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (servedView instanceof WebView) {
+        if (servedView instanceof WebView && Build.VERSION.SDK_INT >= 27) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread
@@ -44,7 +45,11 @@ public class SetSelection extends TextAction {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    webView.evaluateJavascript(String.format(WebViewInputScripts.SelectScript, argFrom, argTo), null);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                        webView.evaluateJavascript(String.format(WebViewInputScripts.SelectScript, argFrom, argTo), null);
+                    } else {
+                        webView.loadUrl("javascript:" + String.format(WebViewInputScripts.SelectScript, argFrom, argTo));
+                    }
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -1,8 +1,12 @@
 package sh.calaba.instrumentationbackend.actions.text;
 
+import android.os.Build;
 import android.text.Editable;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+
 import sh.calaba.instrumentationbackend.Result;
 
 public class SetSelection extends TextAction {
@@ -31,6 +35,27 @@ public class SetSelection extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+        if (Build.VERSION.SDK_INT >= 27 && servedView instanceof WebView) {
+            WebView webView = (WebView) servedView;
+
+            // Execute JS on the UI thread
+            webView.post(new Runnable() {
+                @Override
+                public void run() {
+                    WebSettings webSettings = webView.getSettings();
+                    webSettings.setJavaScriptEnabled(true);
+
+                    webView.evaluateJavascript(String.format(WebViewInputScripts.SelectScript, argFrom, argTo), null);
+                }
+            });
+
+            return Result.successResult();
+        }
+
+        if (inputConnection == null) {
+            Result.failedResult(getNoFocusedViewMessage());
+        }
+
         // Find length of non-formatted text
         int textLength = InfoMethodUtil.getTextLength(inputConnection);
         int from, to;

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -36,7 +36,7 @@ public class SetSelection extends TextAction {
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         if (requiresWebViewInput(servedView)) {
-            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.DeleteScript, argFrom, argTo);
+            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.selectTextScript(argFrom, argTo));
         }
 
         // Find length of non-formatted text

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -30,30 +30,13 @@ public class SetSelection extends TextAction {
 
     @Override
     protected String getNoFocusedViewMessage() {
-        return "Unable to set selection, no element has focus";
+        return "Unable to set selection. Make sure that the input element has focus.";
     }
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (servedView instanceof WebView && Build.VERSION.SDK_INT > 27) {
-            WebView webView = (WebView) servedView;
-
-            // Execute JS on the UI thread
-            webView.post(new Runnable() {
-                @Override
-                public void run() {
-                    WebSettings webSettings = webView.getSettings();
-                    webSettings.setJavaScriptEnabled(true);
-
-                    webView.evaluateJavascript(String.format(WebViewInputScripts.SelectScript, argFrom, argTo), null);
-                }
-            });
-
-            return Result.successResult();
-        }
-
-        if (inputConnection == null) {
-            Result.failedResult(getNoFocusedViewMessage());
+        if (requiresWebViewInput(servedView)) {
+            return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.DeleteScript, argFrom, argTo);
         }
 
         // Find length of non-formatted text

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -1,13 +1,13 @@
 package sh.calaba.instrumentationbackend.actions.text;
 
-import android.os.Build;
-import android.text.Editable;
 import android.view.View;
 import android.view.inputmethod.InputConnection;
-import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.query.CompletedFuture;
+
+import java.util.concurrent.Future;
 
 public class SetSelection extends TextAction {
     private static final String USAGE = "This action takes 2 arguments:\n([int] start, [int] end)";
@@ -34,7 +34,7 @@ public class SetSelection extends TextAction {
     }
 
     @Override
-    protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
+    protected Future<Result> executeOnInputThread(final View servedView, final InputConnection inputConnection) {
         if (requiresWebViewInput(servedView)) {
             return evalWebViewInputScript((WebView) servedView, WebViewInputScripts.selectTextScript(argFrom, argTo));
         }
@@ -57,7 +57,7 @@ public class SetSelection extends TextAction {
 
         inputConnection.setSelection(from, to);
 
-        return Result.successResult();
+        return new CompletedFuture<>(Result.successResult());
     }
 
     @Override

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/SetSelection.java
@@ -35,7 +35,7 @@ public class SetSelection extends TextAction {
 
     @Override
     protected Result executeOnInputThread(final View servedView, final InputConnection inputConnection) {
-        if (servedView instanceof WebView && Build.VERSION.SDK_INT >= 27) {
+        if (servedView instanceof WebView && Build.VERSION.SDK_INT > 27) {
             WebView webView = (WebView) servedView;
 
             // Execute JS on the UI thread

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/TextAction.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/TextAction.java
@@ -66,17 +66,23 @@ public abstract class TextAction implements Action {
         }
     }
 
-    /*
+    /**
+     * Verifies is specific WebView input logic required or not.
      * On Android 4 devices we have servedView instanceof WebView and correct input connection, so we don't need to use js logic on old devices.
+     * @param view active view
+     * @return value indicating whether WebView JS input logic required or not
      */
     public static boolean requiresWebViewInput(View view) {
         return view instanceof WebView && Build.VERSION.SDK_INT > 27;
     }
 
-    /*
+    /**
      * Executes JS to handle WebView input operations.
+     * @param webView active WebView
+     * @param script script to execute inside the WebView
+     * @return operation result
      */
-    public static Result evalWebViewInputScript(WebView webView, String script, Object ... scriptParams) {
+    public static Result evalWebViewInputScript(WebView webView, String script) {
         try {
             // Execute JS on the UI thread
             webView.post(new Runnable() {
@@ -85,7 +91,7 @@ public abstract class TextAction implements Action {
                     WebSettings webSettings = webView.getSettings();
                     webSettings.setJavaScriptEnabled(true);
 
-                    webView.evaluateJavascript(String.format(script, scriptParams), null);
+                    webView.evaluateJavascript(script, null);
                 }
             });
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/TextAction.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/TextAction.java
@@ -39,7 +39,7 @@ public abstract class TextAction implements Action {
             return Result.failedResult(e.getMessage());
         }
 
-        if (servedView == null || inputConnection == null) {
+        if (servedView == null) {
             return Result.failedResult(getNoFocusedViewMessage());
         }
 

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
@@ -53,8 +53,7 @@ public class WebViewInputScripts {
             "      simulateKeyEvent(element, ch);\n" +
             "    }\n" +
             "  }\n" +
-            "}\n" +
-            "enterText('%1$s');";
+            "}\n";
 
     private static final String deleteScript =
             "function removeCharacter(activeElement, rtl) {  \n" +
@@ -147,8 +146,7 @@ public class WebViewInputScripts {
             "    removeCharacter(element, false);\n" +
             "    simulateKeyEvent(element, false);\n" +
             "  }\n" +
-            "}\n" +
-            "deleteText(%1$s,%2$s);";
+            "}\n";
 
     private static final String selectScript =
             "function selectText(argFrom, argTo) {\n" +
@@ -183,8 +181,21 @@ public class WebViewInputScripts {
             "    selection.removeAllRanges();\n" +
             "    selection.addRange(range);\n" +
             "  }\n" +
-            "}\n" +
-            "selectText(%1$s,%2$s);";
+            "}\n";
+
+    private static final String outputStrategyScript =
+            "(function() {\n" +
+            "  try {\n" +
+            "    %1$s\n" +
+            "    return null;\n" +
+            "  } catch (e) {\n" +
+            "    return 'JS exception: ' + e;\n" +
+            "  }\n" +
+            "})();";
+
+    private static String useOutputStrategyScript(String inputScript) {
+        return String.format(outputStrategyScript, inputScript);
+    }
 
     /**
      * Allows to add text according to caret position and selection
@@ -192,7 +203,7 @@ public class WebViewInputScripts {
      * @return script to enter text into active WebView field
      */
     public static String enterTextScript(String text) {
-        return String.format(enterScript, text.replaceAll("\'", "\\\\x27"));
+        return enterScript + useOutputStrategyScript(String.format("enterText('%1$s');", text.replaceAll("\'", "\\\\x27")));
     }
 
 
@@ -203,7 +214,7 @@ public class WebViewInputScripts {
      * @return script to remove text into active WebView field
      */
     public static String deleteTextScript(int beforeLength, int afterLength) {
-        return String.format(deleteScript, beforeLength, afterLength);
+        return deleteScript + useOutputStrategyScript(String.format("deleteText(%1$s,%2$s);", beforeLength, afterLength));
     }
 
 
@@ -214,6 +225,6 @@ public class WebViewInputScripts {
      * @return script to select text into active WebView field
      */
     public static String selectTextScript(int from, int to) {
-        return String.format(selectScript, from, to);
+        return selectScript + useOutputStrategyScript(String.format("selectText(%1$s,%2$s);", from, to));
     }
 }

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
@@ -4,12 +4,11 @@ public class WebViewInputScripts {
 
     // This script allows to add text according to caret position and selection
     static final String InputScript =
-            "    var activeElement = document.activeElement;\n" +
-            "    var from = 0;\n" +
-            "    var to = 0;\n" +
-            "    var text = '%s';\n" +
-            "    if (!text)\n" +
-            "        return;\n" +
+            "var activeElement = document.activeElement;\n" +
+            "var from = 0;\n" +
+            "var to = 0;\n" +
+            "var text = '%1$s';\n" +
+            "if (text) {\n" +
             "    if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
             "        from = activeElement.selectionStart;\n" +
             "        to = activeElement.selectionEnd;\n" +
@@ -32,87 +31,88 @@ public class WebViewInputScripts {
             "            sel.removeAllRanges();\n" +
             "            sel.addRange(range);\n" +
             "        }\n" +
-            "    }";
+            "    }\n" +
+            "}";
 
     // This script allows to remove text according to caret position and selection
     static final String DeleteScript =
-            "    var activeElement = document.activeElement;\n" +
-            "    var from = 0;\n" +
-            "     var to = 0;\n" +
-            "     var value;\n" +
-            "     var argBeforeLength = '%1$s';\n" +
-            "     var argAfterLength = '%2$s';\n" +
-            "     if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
-            "         from = activeElement.selectionStart;\n" +
-            "         to = activeElement.selectionEnd;\n" +
-            "         value = activeElement.value;\n" +
-            "     } else if (window.getSelection) {\n" +
-            "         var sel = window.getSelection();\n" +
-            "         if (sel.rangeCount) {\n" +
-            "             var range = sel.getRangeAt(0);\n" +
-            "             from = range.startOffset;\n" +
-            "             to = range.endOffset;\n" +
-            "             value = activeElement.innerHTML;\n" +
-            "         }\n" +
-            "     }\n" +
-            "     var beforeLength, afterLength;\n" +
-            "     var textLength = value.length;\n" +
-            "     if (argBeforeLength < 0) {\n" +
-            "         beforeLength = textLength + argBeforeLength + 1;\n" +
-            "     } else {\n" +
-            "         beforeLength = argBeforeLength;\n" +
-            "     }\n" +
-            "     if (argAfterLength < 0) {\n" +
-            "         afterLength = textLength + argAfterLength + 1;\n" +
-            "     } else {\n" +
-            "         afterLength = argAfterLength;\n" +
-            "     }\n" +
-            "     var resultValue = value.substring(0, from - beforeLength) + value.substring(to + afterLength, value.length);\n" +
-            "     if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
-            "         activeElement.value = resultValue;\n" +
-            "     } else {\n" +
-            "         activeElement.innerHTML = resultValue;\n" +
-            "     }";
+            "var activeElement = document.activeElement;\n" +
+            "var from = 0;\n" +
+            "var to = 0;\n" +
+            "var value;\n" +
+            "var argBeforeLength = %1$s;\n" +
+            "var argAfterLength = %2$s;\n" +
+            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "    from = activeElement.selectionStart;\n" +
+            "    to = activeElement.selectionEnd;\n" +
+            "    value = activeElement.value;\n" +
+            "} else if (window.getSelection) {\n" +
+            "    var sel = window.getSelection();\n" +
+            "    if (sel.rangeCount) {\n" +
+            "        var range = sel.getRangeAt(0);\n" +
+            "        from = range.startOffset;\n" +
+            "        to = range.endOffset;\n" +
+            "        value = activeElement.innerHTML;\n" +
+            "    }\n" +
+            "}\n" +
+            "var beforeLength, afterLength;\n" +
+            "var textLength = value.length;\n" +
+            "if (argBeforeLength < 0) {\n" +
+            "    beforeLength = textLength + argBeforeLength + 1;\n" +
+            "} else {\n" +
+            "    beforeLength = argBeforeLength;\n" +
+            "}\n" +
+            "if (argAfterLength < 0) {\n" +
+            "    afterLength = textLength + argAfterLength + 1;\n" +
+            "} else {\n" +
+            "    afterLength = argAfterLength;\n" +
+            "}\n" +
+            "var resultValue = value.substring(0, from - beforeLength) + value.substring(to + afterLength, value.length);\n" +
+            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "    activeElement.value = resultValue;\n" +
+            "} else {\n" +
+            "    activeElement.innerHTML = resultValue;\n" +
+            "}";
 
     // This script allows to add selection inside active element
     static final String SelectScript =
-            "    var activeElement = document.activeElement;\n" +
-            "    var tagName = activeElement.tagName.toLowerCase();\n" +
-            "    var from;\n" +
-            "    var to;\n" +
-            "    var textLength;\n" +
-            "    var argFrom = '%1$s';\n" +
-            "    var argTo = '%2$s';\n" +
-            "    if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
-            "        textLength = activeElement.value.length;\n" +
-            "    } else {\n" +
-            "        textLength = activeElement.innerHTML.length;\n" +
+            "var activeElement = document.activeElement;\n" +
+            "var tagName = activeElement.tagName.toLowerCase();\n" +
+            "var from;\n" +
+            "var to;\n" +
+            "var textLength;\n" +
+            "var argFrom = %1$s;\n" +
+            "var argTo = %2$s;\n" +
+            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "    textLength = activeElement.value.length;\n" +
+            "} else {\n" +
+            "    textLength = activeElement.innerHTML.length;\n" +
+            "}\n" +
+            "if (argFrom < 0) {\n" +
+            "    from = textLength + argFrom + 1;\n" +
+            "} else {\n" +
+            "    from = argFrom;\n" +
+            "}\n" +
+            "if (argTo < 0) {\n" +
+            "    to = textLength + argTo + 1;\n" +
+            "} else {\n" +
+            "    to = argTo;\n" +
+            "}\n" +
+            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "    activeElement.focus();\n" +
+            "    activeElement.setSelectionRange(from, to);\n" +
+            "} else if (window.getSelection) {\n" +
+            "    var selection = window.getSelection();\n" +
+            "    var range = document.createRange();\n" +
+            "    if (from + 1 <= textLength) {\n" +
+            "        from++;\n" +
             "    }\n" +
-            "    if (argFrom < 0) {\n" +
-            "        from = textLength + argFrom + 1;\n" +
-            "    } else {\n" +
-            "        from = argFrom;\n" +
-            "    }\n" +
-            "    if (argTo < 0) {\n" +
-            "        to = textLength + argTo + 1;\n" +
-            "    } else {\n" +
-            "        to = argTo;\n" +
-            "    }\n" +
-            "    if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
-            "        activeElement.focus();\n" +
-            "        activeElement.setSelectionRange(from, to);\n" +
-            "    } else if (window.getSelection) {\n" +
-            "        var selection = window.getSelection();\n" +
-            "        var range = document.createRange();\n" +
-            "        if (from + 1 <= textLength) {\n" +
-            "            from++;\n" +
-            "        }\n" +
-            "        if (to + 1 <= textLength) {\n" +
-            "            to++;\n" +
-            "        }" +
-            "        range.setStart(activeElement.firstChild, from);\n" +
-            "        range.setEnd(activeElement.firstChild, to);\n" +
-            "        selection.removeAllRanges();\n" +
-            "        selection.addRange(range);\n" +
-            "    }";
+            "    if (to + 1 <= textLength) {\n" +
+            "        to++;\n" +
+            "    }" +
+            "    range.setStart(activeElement.firstChild, from);\n" +
+            "    range.setEnd(activeElement.firstChild, to);\n" +
+            "    selection.removeAllRanges();\n" +
+            "    selection.addRange(range);\n" +
+            "}";
 }

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
@@ -1,0 +1,118 @@
+package sh.calaba.instrumentationbackend.actions.text;
+
+public class WebViewInputScripts {
+
+    // This script allows to add text according to caret position and selection
+    static final String InputScript =
+            "    var activeElement = document.activeElement;\n" +
+            "    var from = 0;\n" +
+            "    var to = 0;\n" +
+            "    var text = '%s';\n" +
+            "    if (!text)\n" +
+            "        return;\n" +
+            "    if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "        from = activeElement.selectionStart;\n" +
+            "        to = activeElement.selectionEnd;\n" +
+            "        var inputText = activeElement.value;\n" +
+            "        activeElement.value = inputText.substring(0, from) + text + inputText.substring(to, inputText.length);\n" +
+            "        var caretPos = from + text.length;\n" +
+            "        activeElement.focus();\n" +
+            "        activeElement.setSelectionRange(caretPos, caretPos);\n" +
+            "    } else if (window.getSelection) {\n" +
+            "        var sel = window.getSelection();\n" +
+            "        if (sel.rangeCount) {\n" +
+            "            var range = sel.getRangeAt(0);\n" +
+            "            from = range.startOffset;\n" +
+            "            to = range.endOffset;\n" +
+            "            range.deleteContents();\n" +
+            "            var textNode = document.createTextNode(text);\n" +
+            "            range.insertNode(textNode);\n" +
+            "            range.setStart(textNode, textNode.length);\n" +
+            "            range.setEnd(textNode, textNode.length);\n" +
+            "            sel.removeAllRanges();\n" +
+            "            sel.addRange(range);\n" +
+            "        }\n" +
+            "    }";
+
+    // This script allows to remove text according to caret position and selection
+    static final String DeleteScript =
+            "    var activeElement = document.activeElement;\n" +
+            "    var from = 0;\n" +
+            "     var to = 0;\n" +
+            "     var value;\n" +
+            "     var argBeforeLength = '%1$s';\n" +
+            "     var argAfterLength = '%2$s';\n" +
+            "     if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "         from = activeElement.selectionStart;\n" +
+            "         to = activeElement.selectionEnd;\n" +
+            "         value = activeElement.value;\n" +
+            "     } else if (window.getSelection) {\n" +
+            "         var sel = window.getSelection();\n" +
+            "         if (sel.rangeCount) {\n" +
+            "             var range = sel.getRangeAt(0);\n" +
+            "             from = range.startOffset;\n" +
+            "             to = range.endOffset;\n" +
+            "             value = activeElement.innerHTML;\n" +
+            "         }\n" +
+            "     }\n" +
+            "     var beforeLength, afterLength;\n" +
+            "     var textLength = value.length;\n" +
+            "     if (argBeforeLength < 0) {\n" +
+            "         beforeLength = textLength + argBeforeLength + 1;\n" +
+            "     } else {\n" +
+            "         beforeLength = argBeforeLength;\n" +
+            "     }\n" +
+            "     if (argAfterLength < 0) {\n" +
+            "         afterLength = textLength + argAfterLength + 1;\n" +
+            "     } else {\n" +
+            "         afterLength = argAfterLength;\n" +
+            "     }\n" +
+            "     var resultValue = value.substring(0, from - beforeLength) + value.substring(to + afterLength, value.length);\n" +
+            "     if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "         activeElement.value = resultValue;\n" +
+            "     } else {\n" +
+            "         activeElement.innerHTML = resultValue;\n" +
+            "     }";
+
+    // This script allows to add selection inside active element
+    static final String SelectScript =
+            "    var activeElement = document.activeElement;\n" +
+            "    var tagName = activeElement.tagName.toLowerCase();\n" +
+            "    var from;\n" +
+            "    var to;\n" +
+            "    var textLength;\n" +
+            "    var argFrom = '%1$s';\n" +
+            "    var argTo = '%2$s';\n" +
+            "    if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "        textLength = activeElement.value.length;\n" +
+            "    } else {\n" +
+            "        textLength = activeElement.innerHTML.length;\n" +
+            "    }\n" +
+            "    if (argFrom < 0) {\n" +
+            "        from = textLength + argFrom + 1;\n" +
+            "    } else {\n" +
+            "        from = argFrom;\n" +
+            "    }\n" +
+            "    if (argTo < 0) {\n" +
+            "        to = textLength + argTo + 1;\n" +
+            "    } else {\n" +
+            "        to = argTo;\n" +
+            "    }\n" +
+            "    if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "        activeElement.focus();\n" +
+            "        activeElement.setSelectionRange(from, to);\n" +
+            "    } else if (window.getSelection) {\n" +
+            "        var selection = window.getSelection();\n" +
+            "        var range = document.createRange();\n" +
+            "        if (from + 1 <= textLength) {\n" +
+            "            from++;\n" +
+            "        }\n" +
+            "        if (to + 1 <= textLength) {\n" +
+            "            to++;\n" +
+            "        }" +
+            "        range.setStart(activeElement.firstChild, from);\n" +
+            "        range.setEnd(activeElement.firstChild, to);\n" +
+            "        selection.removeAllRanges();\n" +
+            "        selection.addRange(range);\n" +
+            "    }";
+}

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
@@ -4,115 +4,188 @@ public class WebViewInputScripts {
 
     // This script allows to add text according to caret position and selection
     static final String InputScript =
-            "var activeElement = document.activeElement;\n" +
-            "var from = 0;\n" +
-            "var to = 0;\n" +
-            "var text = '%1$s';\n" +
-            "if (text) {\n" +
-            "    if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
-            "        from = activeElement.selectionStart;\n" +
-            "        to = activeElement.selectionEnd;\n" +
-            "        var inputText = activeElement.value;\n" +
-            "        activeElement.value = inputText.substring(0, from) + text + inputText.substring(to, inputText.length);\n" +
-            "        var caretPos = from + text.length;\n" +
-            "        activeElement.focus();\n" +
-            "        activeElement.setSelectionRange(caretPos, caretPos);\n" +
-            "    } else if (window.getSelection) {\n" +
-            "        var sel = window.getSelection();\n" +
-            "        if (sel.rangeCount) {\n" +
-            "            var range = sel.getRangeAt(0);\n" +
-            "            from = range.startOffset;\n" +
-            "            to = range.endOffset;\n" +
-            "            range.deleteContents();\n" +
-            "            var textNode = document.createTextNode(text);\n" +
-            "            range.insertNode(textNode);\n" +
-            "            range.setStart(textNode, textNode.length);\n" +
-            "            range.setEnd(textNode, textNode.length);\n" +
-            "            sel.removeAllRanges();\n" +
-            "            sel.addRange(range);\n" +
-            "        }\n" +
+            "function enterCharacter(activeElement, character) {  \n" +
+            "  var from = 0; var to = 0;\n" +
+            "  if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "    from = activeElement.selectionStart;\n" +
+            "    to = activeElement.selectionEnd;\n" +
+            "    var inputText = activeElement.value;\n" +
+            "    activeElement.value = inputText.substring(0, from) + character + inputText.substring(to, inputText.length);\n" +
+            "    var caretPos = from + 1;\n" +
+            "    activeElement.setSelectionRange(caretPos, caretPos);\n" +
+            "  } else if (window.getSelection) {\n" +
+            "    var sel = window.getSelection();\n" +
+            "    if (sel.rangeCount) {\n" +
+            "      var range = sel.getRangeAt(0);\n" +
+            "      from = range.startOffset;\n" +
+            "      to = range.endOffset;\n" +
+            "      range.deleteContents();\n" +
+            "      var textNode = document.createTextNode(character);\n" +
+            "      range.insertNode(textNode);\n" +
+            "      range.setStart(textNode, textNode.length);\n" +
+            "      range.setEnd(textNode, textNode.length);\n" +
+            "      sel.removeAllRanges();\n" +
+            "      sel.addRange(range);\n" +
             "    }\n" +
-            "}";
+            "  }\n" +
+            "}\n" +
+            "function simulateKeyEvent(activeElement, character) {\n" +
+            "  var keyboardEvent;\n" +
+            "  var charCode = character.charCodeAt(0);\n" +
+            "  keyboardEvent = new KeyboardEvent('keydown');\n" +
+            "  keyboardEvent.key = character;\n" +
+            "  keyboardEvent.charCode = charCode;\n" +
+            "  activeElement.dispatchEvent(keyboardEvent);\n" +
+            "  keyboardEvent = new KeyboardEvent('keyup');\n" +
+            "  keyboardEvent.key = character;\n" +
+            "  keyboardEvent.charCode = charCode;\n" +
+            "  activeElement.dispatchEvent(keyboardEvent);\n" +
+            "  keyboardEvent = new KeyboardEvent('keypress');\n" +
+            "  keyboardEvent.key = character;\n" +
+            "  keyboardEvent.charCode = charCode;\n" +
+            "  activeElement.dispatchEvent(keyboardEvent);\n" +
+            "}\n" +
+            "function enterText(text) {\n" +
+            "  if (text) {\n" +
+            "    var element = document.activeElement;\n" +
+            "    for (var i = 0; i < text.length; i++) {\n" +
+            "      var ch = text.charAt(i);\n" +
+            "      enterCharacter(element, ch);\n" +
+            "      simulateKeyEvent(element, ch);\n" +
+            "    }\n" +
+            "  }\n" +
+            "}\n" +
+            "enterText('%1$s');";
 
     // This script allows to remove text according to caret position and selection
     static final String DeleteScript =
-            "var activeElement = document.activeElement;\n" +
-            "var from = 0;\n" +
-            "var to = 0;\n" +
-            "var value;\n" +
-            "var argBeforeLength = %1$s;\n" +
-            "var argAfterLength = %2$s;\n" +
-            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "function removeCharacter(activeElement, rtl) {  \n" +
+            "  var from = 0;\n" +
+            "  var value;\n" +
+            "  if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
             "    from = activeElement.selectionStart;\n" +
-            "    to = activeElement.selectionEnd;\n" +
             "    value = activeElement.value;\n" +
-            "} else if (window.getSelection) {\n" +
+            "  } else if (window.getSelection) {\n" +
             "    var sel = window.getSelection();\n" +
             "    if (sel.rangeCount) {\n" +
-            "        var range = sel.getRangeAt(0);\n" +
-            "        from = range.startOffset;\n" +
-            "        to = range.endOffset;\n" +
-            "        value = activeElement.innerHTML;\n" +
+            "      var range = sel.getRangeAt(0);\n" +
+            "      from = range.startOffset;\n" +
+            "      value = activeElement.innerHTML;\n" +
             "    }\n" +
-            "}\n" +
-            "var beforeLength, afterLength;\n" +
-            "var textLength = value.length;\n" +
-            "if (argBeforeLength < 0) {\n" +
-            "    beforeLength = textLength + argBeforeLength + 1;\n" +
-            "} else {\n" +
-            "    beforeLength = argBeforeLength;\n" +
-            "}\n" +
-            "if (argAfterLength < 0) {\n" +
-            "    afterLength = textLength + argAfterLength + 1;\n" +
-            "} else {\n" +
-            "    afterLength = argAfterLength;\n" +
-            "}\n" +
-            "var resultValue = value.substring(0, from - beforeLength) + value.substring(to + afterLength, value.length);\n" +
-            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "  }\n" +
+            "  var textLength = value.length;\n" +
+            "  var resultValue;\n" +
+            "  var caretPos;\n" +
+            "  if (rtl) {\n" +
+            "    caretPos = from - 1;\n" +
+            "    resultValue = value.substring(0, caretPos) + value.substring(from, textLength);\n" +
+            "  } else {\n" +
+            "    caretPos = from;\n" +
+            "    resultValue = value.substring(0, from) + value.substring(caretPos + 1, textLength);\n" +
+            "  }\n" +
+            "  if (caretPos < 0) {\n" +
+            "    caretPos = 0;\n" +
+            "  }\n" +
+            "  if (caretPos > resultValue.length) {\n" +
+            "    caretPos = resultValue.length;\n" +
+            "  }\n" +
+            "  if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
             "    activeElement.value = resultValue;\n" +
-            "} else {\n" +
+            "    activeElement.setSelectionRange(caretPos, caretPos);\n" +
+            "  } else {\n" +
             "    activeElement.innerHTML = resultValue;\n" +
-            "}";
+            "    if (window.getSelection && activeElement.firstChild) {\n" +
+            "      var selection = window.getSelection();\n" +
+            "      var newRange = document.createRange();\n" +
+            "      newRange.setStart(activeElement.firstChild, caretPos);\n" +
+            "      newRange.setEnd(activeElement.firstChild, caretPos);\n" +
+            "      selection.removeAllRanges();\n" +
+            "      selection.addRange(newRange);\n" +
+            "    }\n" +
+            "  }\n" +
+            "}\n" +
+            "function simulateKeyEvent(activeElement, rtl) {\n" +
+            "  var keyCode;\n" +
+            "  if (rtl) {\n" +
+            "    keyCode = 8; // backspace\n" +
+            "  } else {\n" +
+            "    keyCode = 46; // delete\n" +
+            "  }\n" +
+            "  var keyboardEvent;\n" +
+            "  keyboardEvent = new KeyboardEvent('keydown');\n" +
+            "  keyboardEvent.which = keyCode;\n" +
+            "  activeElement.dispatchEvent(keyboardEvent);\n" +
+            "  keyboardEvent = new KeyboardEvent('keyup');\n" +
+            "  keyboardEvent.which = keyCode;\n" +
+            "  activeElement.dispatchEvent(keyboardEvent);\n" +
+            "  keyboardEvent = new KeyboardEvent('keypress');\n" +
+            "  keyboardEvent.which = keyCode;\n" +
+            "  activeElement.dispatchEvent(keyboardEvent);\n" +
+            "}\n" +
+            "function deleteText(argBeforeLength, argAfterLength) {\n" +
+            "  var element = document.activeElement;\n" +
+            "  var textLength;\n" +
+            "  var beforeLength; var afterLength;\n" +
+            "  if (element.selectionStart !== null && typeof element.selectionStart !== 'undefined') {\n" +
+            "    textLength = element.value.length;\n" +
+            "  } else {\n" +
+            "    textLength = element.innerHTML.length;\n" +
+            "  }\n" +
+            "  if (argBeforeLength < 0) {\n" +
+            "    beforeLength = textLength + argBeforeLength + 1;\n" +
+            "  } else {\n" +
+            "    beforeLength = argBeforeLength;\n" +
+            "  }\n" +
+            "  if (argAfterLength < 0) {\n" +
+            "    afterLength = textLength + argAfterLength + 1;\n" +
+            "  } else {\n" +
+            "    afterLength = argAfterLength;\n" +
+            "  }\n" +
+            "  for (var i = 0; i < beforeLength; i++) {\n" +
+            "    removeCharacter(element, true);\n" +
+            "    simulateKeyEvent(element, true);\n" +
+            "  }\n" +
+            "  for (var j = 0; j < afterLength; j++) {\n" +
+            "    removeCharacter(element, false);\n" +
+            "    simulateKeyEvent(element, false);\n" +
+            "  }\n" +
+            "}\n" +
+            "deleteText(%1$s,%2$s);";
 
     // This script allows to add selection inside active element
     static final String SelectScript =
-            "var activeElement = document.activeElement;\n" +
-            "var tagName = activeElement.tagName.toLowerCase();\n" +
-            "var from;\n" +
-            "var to;\n" +
-            "var textLength;\n" +
-            "var argFrom = %1$s;\n" +
-            "var argTo = %2$s;\n" +
-            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "function selectText(argFrom, argTo) {\n" +
+            "  var activeElement = document.activeElement;\n" +
+            "  var tagName = activeElement.tagName.toLowerCase();\n" +
+            "  var from;\n" +
+            "  var to;\n" +
+            "  var textLength;\n" +
+            "  if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
             "    textLength = activeElement.value.length;\n" +
-            "} else {\n" +
+            "  } else {\n" +
             "    textLength = activeElement.innerHTML.length;\n" +
-            "}\n" +
-            "if (argFrom < 0) {\n" +
+            "  }\n" +
+            "  if (argFrom < 0) {\n" +
             "    from = textLength + argFrom + 1;\n" +
-            "} else {\n" +
+            "  } else {\n" +
             "    from = argFrom;\n" +
-            "}\n" +
-            "if (argTo < 0) {\n" +
+            "  }\n" +
+            "  if (argTo < 0) {\n" +
             "    to = textLength + argTo + 1;\n" +
-            "} else {\n" +
+            "  } else {\n" +
             "    to = argTo;\n" +
-            "}\n" +
-            "if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
+            "  }\n" +
+            "  if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
             "    activeElement.focus();\n" +
             "    activeElement.setSelectionRange(from, to);\n" +
-            "} else if (window.getSelection) {\n" +
+            "  } else if (window.getSelection) {\n" +
             "    var selection = window.getSelection();\n" +
             "    var range = document.createRange();\n" +
-            "    if (from + 1 <= textLength) {\n" +
-            "        from++;\n" +
-            "    }\n" +
-            "    if (to + 1 <= textLength) {\n" +
-            "        to++;\n" +
-            "    }" +
             "    range.setStart(activeElement.firstChild, from);\n" +
             "    range.setEnd(activeElement.firstChild, to);\n" +
             "    selection.removeAllRanges();\n" +
             "    selection.addRange(range);\n" +
-            "}";
+            "  }\n" +
+            "}\n" +
+            "selectText(%1$s,%2$s);";
 }

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/actions/text/WebViewInputScripts.java
@@ -2,8 +2,7 @@ package sh.calaba.instrumentationbackend.actions.text;
 
 public class WebViewInputScripts {
 
-    // This script allows to add text according to caret position and selection
-    static final String InputScript =
+    private static final String enterScript =
             "function enterCharacter(activeElement, character) {  \n" +
             "  var from = 0; var to = 0;\n" +
             "  if (activeElement.selectionStart !== null && typeof activeElement.selectionStart !== 'undefined') {\n" +
@@ -57,8 +56,7 @@ public class WebViewInputScripts {
             "}\n" +
             "enterText('%1$s');";
 
-    // This script allows to remove text according to caret position and selection
-    static final String DeleteScript =
+    private static final String deleteScript =
             "function removeCharacter(activeElement, rtl) {  \n" +
             "  var from = 0;\n" +
             "  var value;\n" +
@@ -152,8 +150,7 @@ public class WebViewInputScripts {
             "}\n" +
             "deleteText(%1$s,%2$s);";
 
-    // This script allows to add selection inside active element
-    static final String SelectScript =
+    private static final String selectScript =
             "function selectText(argFrom, argTo) {\n" +
             "  var activeElement = document.activeElement;\n" +
             "  var tagName = activeElement.tagName.toLowerCase();\n" +
@@ -188,4 +185,35 @@ public class WebViewInputScripts {
             "  }\n" +
             "}\n" +
             "selectText(%1$s,%2$s);";
+
+    /**
+     * Allows to add text according to caret position and selection
+     * @param text text to input
+     * @return script to enter text into active WebView field
+     */
+    public static String enterTextScript(String text) {
+        return String.format(enterScript, text.replaceAll("\'", "\\\\x27"));
+    }
+
+
+    /**
+     * Allows to delete text according to caret position and selection
+     * @param beforeLength number of characters before the current cursor position
+     * @param afterLength number of characters after the current cursor position
+     * @return script to remove text into active WebView field
+     */
+    public static String deleteTextScript(int beforeLength, int afterLength) {
+        return String.format(deleteScript, beforeLength, afterLength);
+    }
+
+
+    /**
+     * Allows to add selection inside active element
+     * @param from the character index where the selection should start
+     * @param to the character index where the selection should end
+     * @return script to select text into active WebView field
+     */
+    public static String selectTextScript(int from, int to) {
+        return String.format(selectScript, from, to);
+    }
 }

--- a/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/utils/CompletableFuture.java
+++ b/server/instrumentation-backend/src/main/java/sh/calaba/instrumentationbackend/utils/CompletableFuture.java
@@ -1,0 +1,50 @@
+package sh.calaba.instrumentationbackend.utils;
+
+import java.util.concurrent.*;
+
+public class CompletableFuture<T> implements Future<T> {
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile T result = null;
+
+    @Override
+    public boolean cancel(boolean b) {
+        return false; // indicates that task can not be cancelled
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return latch.getCount() == 0L;
+    }
+
+    @Override
+    public T get() throws InterruptedException {
+        latch.await();
+        return result;
+    }
+
+    @Override
+    public T get(long time, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+        if (latch.await(time, timeUnit)) {
+            return result;
+        } else {
+            throw new TimeoutException();
+        }
+    }
+
+    /**
+     * Completes the future and wakes up everyone stuck in get().
+     * @param result
+     * @return
+     */
+    public CompletableFuture<T> complete(T result) {
+        this.result = result;
+        latch.countDown();
+        return this;
+    }
+}


### PR DESCRIPTION
**Changes:**
- Added logic to retrieve inputConnection without reflection on android 28+ (P beta 2 +).
- Implemented logic to add text to web elements via JS code on server side.
- Implemented logic to handle deleteSurroundingText from JS.
- Implemented logic to set selection.

**How this works:**
- KeyboardEnterText: adds text according to cursor position. If some text was selected, new one will replace selected text. This logic adds symbol by symbol and trigger native events to simulate real input. After adding, cursor position will be moved at the end of new text.
- SetSelection: adds selection inside active element. For editable elements without built-in selection methods (like contenteditable elements), js logic creates native ranges, taking into account the text offset for js ranges.
- DeleteSurroundingText: removes symbols from left and right of the cursor in accordance with parameters. This logic removes symbol by symbol and trigger native events to simulate real delete operation. 

JS logic tested with input, textarea and content editable elements.