### PR TITLE
Fixed deprecated target api popup issue on Android P

### DIFF
--- a/server/AndroidManifest.xml
+++ b/server/AndroidManifest.xml
@@ -4,11 +4,11 @@
     android:versionCode="4"
     android:versionName="0.4.0">
 
-    <application android:label="instrumentation_backend"
-        android:largeHeap="true">
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="22" />
 
-      <uses-sdk android:minSdkVersion="8"
-          android:targetSdkVersion="24"/>
+    <application android:label="instrumentation_backend"
+      android:largeHeap="true"
+      android:debuggable="true">
 
       <uses-library android:name="android.test.runner" />
       <uses-library android:name="com.google.android.maps" android:required="false" />

--- a/server/app/build.gradle
+++ b/server/app/build.gradle
@@ -11,13 +11,13 @@ def apkName = "app-debug-androidTest.apk"
 def serverApkName = "TestServer.apk"
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 22
     defaultConfig {
         applicationId "sh.calaba.instrumentationbackend"
         //noinspection MinSdkTooLow
         minSdkVersion 8
         //noinspection OldTargetApi
-        targetSdkVersion 24
+        targetSdkVersion 22
         versionCode 4
         versionName "0.4.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
**Problem:**
On Android P when we try to execute tests we have popup "This app was built for an older version of Android ...". This popup breaks test execution because UI elements can not be found under this popup.

**Root-cause:**
We have incorrect manifest structure so Android P can't recognize target api version.
After fixes we need to set target sdk >= 19 but < 24 to create reporter file (e.g. calabash_failure.out) inside data directory. If we will set target api >=24 we can't create public readable files in data dir on newer Android versions: https://developer.android.com/about/versions/nougat/android-7.0-changes#permfilesys
In addition, we need to change logic to create MODE_WORLD_READABLE files for api > 23: we need to use MODE_PRIVATE and set file perm via java api because MODE_WORLD_READABLE triggers security exception when target api >= 17.
These changes removes deprecated target api popup and calabash android server will be ready for android P.

**Changes:**
- Added logic to create reporter files on newer android versions.
- Fixed manifest.
- Changed target sdk.

---
Local UI tests passed. Additional tests in progress.