### PR TITLE
Added workaround for Android 2.3.x: verify that the element isMarked without reflection

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/ast/UIQueryASTWith.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/ast/UIQueryASTWith.java
@@ -15,7 +15,9 @@ import org.antlr.runtime.tree.CommonTree;
 import sh.calaba.instrumentationbackend.actions.webview.CalabashChromeClient;
 import sh.calaba.instrumentationbackend.actions.webview.QueryHelper;
 
+import android.os.Build;
 import android.view.View;
+import android.widget.TextView;
 
 import sh.calaba.instrumentationbackend.query.WebContainer;
 import sh.calaba.instrumentationbackend.query.ui.UIObject;
@@ -289,6 +291,18 @@ public class UIQueryASTWith implements UIQueryAST {
 			return true;
 		}
 
+		// Workaround for Android 2.3.x: retrieve text and hint manually to resolve issue with AppCompat elements.
+		if (Build.VERSION.SDK_INT <= 10 && view instanceof TextView) {
+			TextView element = (TextView) view;
+			Object text = element.getText();
+			Object hint = element.getHint();
+
+			if ((text != null && text.toString().equals(expected))
+					|| (hint != null && hint.toString().equals(expected))) {
+				return true;
+			}
+		}
+
 		List<Method> methods = textMethodsForClass.get(view.getClass());
 		for (Method	method : methods) {
 			try {
@@ -308,7 +322,7 @@ public class UIQueryASTWith implements UIQueryAST {
 	public static UIQueryASTWith fromAST(CommonTree step) {
 		CommonTree prop = (CommonTree) step.getChild(0);
 		CommonTree val = (CommonTree) step.getChild(1);
-		
+
 		Object parsedVal = UIQueryUtils.parseValue(val);
 		return new UIQueryASTWith(prop.getText(), parsedVal);
 	}

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/ast/UIQueryASTWith.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/ast/UIQueryASTWith.java
@@ -291,7 +291,9 @@ public class UIQueryASTWith implements UIQueryAST {
 			return true;
 		}
 
-		// Workaround for Android 2.3.x: retrieve text and hint manually to resolve issue with AppCompat elements.
+		// Workaround for Android 2.3.x: retrieve text and hint without refection
+		// to resolve issue with AppCompat TextView elements, e.g. android.support.v7.widget.AppCompatButton.
+		// getDeclaredMethods() for AppCompat TextView elements triggers NoSuchMethodException exception on android API <= 10.
 		if (Build.VERSION.SDK_INT <= 10 && view instanceof TextView) {
 			TextView element = (TextView) view;
 			Object text = element.getText();


### PR DESCRIPTION
**Problem:** on android api <=10 getDeclaredMethods triggers exception for AppCompatButton class. This is internal Android issue on API <=10.

We are using
```
try {
    textMethods.add(key.getMethod(methodName));
} catch (NoSuchMethodException e) {
    continue;
}
```
which triggers exception for android.support.v7.widget.AppCompatButton:
```
W/dalvikvm( 7519): Unable to match class for part: 'Landroid/view/accessibility/AccessibilityNodeInfo;)V'
W/System.err( 7519): java.lang.NoSuchMethodException
W/System.err( 7519): at java.lang.Class.getDeclaredMethods(Native Method)
W/System.err( 7519): at java.lang.ClassCache.getDeclaredPublicMethods(ClassCache.java:153)
W/System.err( 7519): at java.lang.ClassCache.getMethodsRecursive(ClassCache.java:216)
W/System.err( 7519): at java.lang.ClassCache.findMethods(ClassCache.java:175)
W/System.err( 7519): at java.lang.ClassCache.getMethods(ClassCache.java:167)
W/System.err( 7519): at java.lang.Class.getMethod(Class.java:961)
```


**Changes:**
Added workaround for Android 2.3.x: retrieve text and hint without reflection to resolve issue with AppCompat elements.

---
Verified locally and in AppCenter.