### PR TITLE
UITest (Android): problem with backslash in query strings

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/Query.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/Query.java
@@ -104,6 +104,8 @@ public class Query {
 
 	@SuppressWarnings("unchecked")
 	public static List<UIQueryAST> parseQuery(String query) {
+		// Replace '\\' with '\\\\' to prevent NoViableAltException ANTLR exception due to incorrect parsing
+		query = query.replaceAll("\\\\", "\\\\\\\\\\\\\\\\");
 		UIQueryLexer lexer = new UIQueryLexer(new ANTLRStringStream(query));
 		UIQueryParser parser = new UIQueryParser(new CommonTokenStream(lexer));
 

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/Query.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/Query.java
@@ -104,7 +104,9 @@ public class Query {
 
 	@SuppressWarnings("unchecked")
 	public static List<UIQueryAST> parseQuery(String query) {
-		// Replace '\\' with '\\\\' to prevent NoViableAltException ANTLR exception due to incorrect parsing
+		// Replace '\\' with '\\\\' to prevent NoViableAltException ANTLR exception due to incorrect parsing:
+		// '\\' is not valid expression for ANTLR but it's valid text value for Android.
+		// Android implicitly escapes this, e.g.: in UI we have "D\A" but the actual text is "D\\A".
 		query = query.replaceAll("\\\\", "\\\\\\\\\\\\\\\\");
 		UIQueryLexer lexer = new UIQueryLexer(new ANTLRStringStream(query));
 		UIQueryParser parser = new UIQueryParser(new CommonTokenStream(lexer));

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/ast/UIQueryUtils.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/query/ast/UIQueryUtils.java
@@ -425,6 +425,7 @@ public class UIQueryUtils {
 			String text = textWithPings
 					.substring(1, textWithPings.length() - 1);
 			text = text.replaceAll("\\\\'", "'");
+			text = text.replaceAll("\\\\\\\\\\\\\\\\", "\\\\");
 			return text;
 		}
 		case UIQueryParser.INT:


### PR DESCRIPTION
**Problem:** https://github.com/xamarin/Xamarin.Forms/issues/3197

**Solution:**
Added replacing to fix ANTLR NoViableAltException exception due to incorrect parsing.