### PR TITLE
Added handling for 'version' get request.

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/HttpServer.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/HttpServer.java
@@ -13,7 +13,6 @@ import java.io.StringWriter;
 import java.lang.InterruptedException;
 import java.lang.Override;
 import java.lang.Runnable;
-import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -22,9 +21,9 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import android.os.Build;
-import android.os.Bundle;
 import dalvik.system.DexClassLoader;
 import sh.calaba.instrumentationbackend.*;
+import sh.calaba.instrumentationbackend.actions.version.Version;
 import sh.calaba.instrumentationbackend.actions.webview.CalabashChromeClient;
 import sh.calaba.instrumentationbackend.json.JSONUtils;
 import sh.calaba.instrumentationbackend.query.InvocationOperation;
@@ -121,6 +120,12 @@ public class HttpServer extends NanoHTTPD {
 			return new NanoHTTPD.Response(HTTP_OK, MIME_HTML, "pong");
 
 		}
+        else if (uri.endsWith("/version")) {
+            String result = toJson(new Version().execute());
+            System.out.println("result:" + result);
+
+            return new NanoHTTPD.Response(HTTP_OK, MIME_HTML, result);
+        }
         else if (uri.endsWith("/start-application")) {
             try {
                 String json = params.getProperty("json");


### PR DESCRIPTION
**Problem:**
The `/version` is a get request. We have separate logic to handle get request for all cases except `/version`. In this case we have a lot of noise in AppCenter device logs like this:

```
I/System.out(14097): URI: /version
I/System.out(14097): params: {}
I/System.out(14097): header: {host=devicehost54.prod, x-session-token=token-token, x-forwarded-for=10.222.150.32, contenttype=application/json;charset=utf-8, connection=close}
I/System.out(14097): params: {}
I/System.out(14097): files: {}
I/System.out(14097): command: null
W/System.err(14097): java.lang.NullPointerException
W/System.err(14097): 	at java.io.StringReader.<init>(StringReader.java:47)
W/System.err(14097): 	at sh.calaba.org.codehaus.jackson.JsonFactory.createJsonParser(JsonFactory.java:636)
W/System.err(14097): 	at sh.calaba.org.codehaus.jackson.map.ObjectMapper.readValue(ObjectMapper.java:1896)
W/System.err(14097): 	at sh.calaba.instrumentationbackend.actions.HttpServer.runCommand(HttpServer.java:785)
W/System.err(14097): 	at sh.calaba.instrumentationbackend.actions.HttpServer.serve(HttpServer.java:767)
W/System.err(14097): 	at sh.calaba.instrumentationbackend.actions.NanoHTTPD$HTTPSession.run(NanoHTTPD.java:487)
W/System.err(14097): 	at java.lang.Thread.run(Thread.java:841)
```

**Changes:**
Added handling for 'version' get request.