### PR TITLE
fix mock location on android Q

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
@@ -19,23 +19,30 @@ import android.provider.Settings;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 
 public class FakeGPSLocation implements Action {
     // Not present in newer SDK, copied here so that we are not forcing users to download a old SDK just to be able to compile
     private static final String ACCESS_MOCK_LOCATION = "android.permission.ACCESS_MOCK_LOCATION";
-    private static LocationProviderThread t;
+    private static final String TEST_PROVIDER = "calabashTestProvider";
+    private static final ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(1);
+    private static ScheduledFuture<?> task;
 
     public static void stopLocationMocking() {
-        if (t != null) {
-            t.finish();
-        }
+        executorService.shutdownNow();
+        LocationManager locationManager = (LocationManager) InstrumentationBackend.instrumentation.getTargetContext().getSystemService(Context.LOCATION_SERVICE);
+        locationManager.removeTestProvider(TEST_PROVIDER);
     }
 
     @Override
     public Result execute(String... args) {
         final double latitude = Double.parseDouble(args[0]);
         final double longitude = Double.parseDouble(args[1]);
+
 
         Context context = InstrumentationBackend.instrumentation.getTargetContext();
 
@@ -44,115 +51,64 @@ public class FakeGPSLocation implements Action {
                 if (Settings.Secure.getInt(context.getContentResolver(), Settings.Secure.ALLOW_MOCK_LOCATION) != 1) {
                     return Result.failedResult("Allow mock location is not enabled.");
                 }
+                if (context.checkCallingOrSelfPermission(ACCESS_MOCK_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                    return Result.failedResult("The application does not have access mock location permission. Add the permission '" + ACCESS_MOCK_LOCATION + "' to your manifest");
+                }
             }
         } catch (Settings.SettingNotFoundException e) {
             return Result.failedResult(e.getMessage());
         }
 
-        if (Build.VERSION.SDK_INT <= 22) {
-            if (context.checkCallingOrSelfPermission(ACCESS_MOCK_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                return Result.failedResult("The application does not have access mock location permission. Add the permission '" + ACCESS_MOCK_LOCATION + "' to your manifest");
-            }
+        // Stop any existing location mocking task
+        if(task != null) {
+            task.cancel(true);
+            task = null;
         }
 
-        if (t != null) {
-            t.finish();
-            t.interrupt();
-
-            try {
-                t.join(5000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-                return Result.fromThrowable(e);
-            }
-
-            if (t.isAlive()) {
-                return Result.failedResult("Failed to stop thread mocking location");
-            }
+        LocationManager locationManager = (LocationManager) InstrumentationBackend.instrumentation.getTargetContext().getSystemService(Context.LOCATION_SERVICE);
+        LocationProvider provider = locationManager.getProvider(TEST_PROVIDER);
+        if(provider == null) {
+            locationManager.addTestProvider(TEST_PROVIDER, false, false, false, false, true, true, true, 1, 1);
+            locationManager.setTestProviderEnabled(TEST_PROVIDER, true);
         }
 
-        t = new LocationProviderThread(latitude, longitude);
-
-        t.start();
-
+        task = executorService.scheduleWithFixedDelay(new LocationProviderRunnable(latitude, longitude, locationManager), 0, 500, TimeUnit.MILLISECONDS);
         return Result.successResult();
     }
 
-
-    private class LocationProviderThread extends Thread {
+    private static class LocationProviderRunnable implements Runnable {
         private final double latitude;
         private final double longitude;
+        private final LocationManager locationManager;
 
-        private boolean finish = false;
-
-        LocationProviderThread(double latitude, double longitude) {
+        LocationProviderRunnable(double latitude, double longitude, LocationManager locationManager) {
             this.latitude = latitude;
             this.longitude = longitude;
+            this.locationManager = locationManager;
         }
 
         @Override
         public void run() {
-            LocationManager locationManager = (LocationManager) InstrumentationBackend.instrumentation.getTargetContext().getSystemService(Context.LOCATION_SERVICE);
-
             final List<String> providerNames = locationManager.getProviders(true);
-            List<String> activeProviderNames = new ArrayList<String>();
+            System.out.println("Mocking location to: (" + latitude + ", " + longitude + ")");
 
             for (String providerName : providerNames) {
-                try {
-                    LocationProvider provider = locationManager.getProvider(providerName);
-                    locationManager.addTestProvider(providerName, provider.requiresNetwork(), provider.requiresSatellite(),
-                            provider.requiresCell(), provider.hasMonetaryCost(), provider.supportsAltitude(), provider.supportsSpeed(),
-                            provider.supportsBearing(), provider.getPowerRequirement(), provider.getAccuracy());
-                    locationManager.setTestProviderEnabled(providerName, true);
-                    activeProviderNames.add(providerName);
-                } catch (IllegalArgumentException e) {
-                    // Ignored
-                }
-            }
-
-            while (!finish) {
-                System.out.println("Mocking location to: (" + latitude + ", " + longitude + ")");
-
-                for (String providerName : activeProviderNames) {
-                    if (locationManager.getProvider(providerName) != null) {
-                        System.out.println("Active provider: " + providerName);
-                        setLocation(locationManager, providerName, latitude, longitude);
-                    }
-                }
-
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    break;
-                }
-            }
-
-            for (String providerName : activeProviderNames) {
-                System.out.println("Removing test provider: " + providerName);
-
-                try {
-                    locationManager.removeTestProvider(providerName);
-                } catch (IllegalArgumentException e) {
-                    // Ignored
+                if (locationManager.getProvider(providerName) != null) {
+                    setLocation(locationManager, providerName, latitude, longitude);
                 }
             }
         }
 
         private void setLocation(LocationManager locationManager, String locationProvider, double latitude, double longitude) {
-
             Location location = new Location(locationProvider);
             location.setLatitude(latitude);
             location.setLongitude(longitude);
-            location.setAccuracy(1);
+            location.setAccuracy(0.1f);
             location.setTime(System.currentTimeMillis());
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
             }
-            locationManager.setTestProviderLocation(locationProvider, location);
-        }
-
-        public void finish() {
-            finish = true;
+            locationManager.setTestProviderLocation(TEST_PROVIDER, location);
         }
     }
 


### PR DESCRIPTION
only register one test provider, make sure that it has a unique name. Mock location with all of the providers as origin (makes google maps and other maps believe we teleported)