### PR TITLE
location mocking: only stop mocking if we started

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/location/FakeGPSLocation.java
@@ -30,12 +30,14 @@ public class FakeGPSLocation implements Action {
     private static final String ACCESS_MOCK_LOCATION = "android.permission.ACCESS_MOCK_LOCATION";
     private static final String TEST_PROVIDER = "calabashTestProvider";
     private static final ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(1);
-    private static ScheduledFuture<?> task;
+    private volatile static ScheduledFuture<?> task;
 
     public static void stopLocationMocking() {
         executorService.shutdownNow();
-        LocationManager locationManager = (LocationManager) InstrumentationBackend.instrumentation.getTargetContext().getSystemService(Context.LOCATION_SERVICE);
-        locationManager.removeTestProvider(TEST_PROVIDER);
+        if (task != null) {
+            LocationManager locationManager = (LocationManager) InstrumentationBackend.instrumentation.getTargetContext().getSystemService(Context.LOCATION_SERVICE);
+            locationManager.removeTestProvider(TEST_PROVIDER);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Fixes:

* Android Test Server: raises requires ACCESS_MOCK_LOCATION permission in stopLocationMocking if location mock is never started [ADO](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/64854)