### PR TITLE
[Hotfix] Remove deprecated URL from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The test-server for Calabash-Android
 
-Automated Functional testing for Android based on cucumber http://calaba.sh
+Automated Functional testing for Android based on cucumber
 
 ### Building
 


### PR DESCRIPTION
This PR removes a deprecated URL that does not belong to the `Calabash` project anymore.