### PR TITLE
Allow actions on parent when using ui automator

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorExecute.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorExecute.java
@@ -8,6 +8,7 @@ import android.support.test.uiautomator.UiObjectNotFoundException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,25 +22,39 @@ public class UiautomatorExecute implements Action {
         UiDevice mDevice = InstrumentationBackend.getUiDevice();
         String text = null;
         try {
-            verifyStrategy(args[0]);
-            verifyAction(args[3]);
-            Method methodName = By.class.getMethod(args[0], String.class);
-            BySelector selector = (BySelector) methodName.invoke(By.class, args[1]);
+            String strategy = args[0];
+            String locator = args[1];
+            String index = args[2];
+            String action = args[3];
 
-            Method methodOperation = UiObject2.class.getMethod(args[3]);
+            verifyStrategy(strategy);
+            verifyAction(action);
 
-            List<UiObject2> objects = mDevice.findObjects(selector);
-            if (objects.isEmpty()) {
-                String errorMessage = String.format("Found no elements for locator: %s by strategy: %s", args[1], args[0]);
+            Method strategyMethod = By.class.getMethod(strategy, String.class);
+            BySelector selector = (BySelector) strategyMethod.invoke(By.class, locator);
+
+            List<UiObject2> matchingObjects = mDevice.findObjects(selector);
+            if (matchingObjects.isEmpty()) {
+                String errorMessage = String.format("Found no elements for locator: %s by strategy: %s", locator, strategy);
                 throw new UiObjectNotFoundException(errorMessage);
             }
-            UiObject2 object = objects.get(Integer.parseInt(args[2]));
+            UiObject2 targetObject = matchingObjects.get(Integer.parseInt(index));
 
-            Object res = methodOperation.invoke(object);
-            if (res != null) {
-                text = res.toString();
+            Object result;
+            if (isActionOnParent(action)) {
+                Method getParentMethod = UiObject2.class.getMethod("getParent");
+                UiObject2 targetObjectParent = (UiObject2) getParentMethod.invoke(targetObject);
+
+                Method actionMethod = UiObject2.class.getMethod(extractAction(action));
+                result = actionMethod.invoke(targetObjectParent);
+            } else {
+                Method actionMethod = UiObject2.class.getMethod(action);
+                result = actionMethod.invoke(targetObject);
             }
 
+            if (result != null) {
+                text = result.toString();
+            }
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
             return new Result(false, e.getMessage());
@@ -69,11 +84,22 @@ public class UiautomatorExecute implements Action {
 
     private static void verifyAction(String action) {
         try {
-            Actions.valueOf(action);
+            Actions.valueOf(extractAction(action));
         } catch (IllegalArgumentException e) {
-            List<Actions> availableActions = Arrays.asList(Actions.values());
-            String errorMessage = String.format("Unsupported action: %s. The list of available actions is %s", action, availableActions);
+            List<String> availableActions = new ArrayList<>();
+            for (Actions a : Actions.values()) {
+                availableActions.add(a.toString());
+                availableActions.add("parent:" + a);
+            }
             throw new IllegalArgumentException(errorMessage);
         }
+    }
+
+    private static boolean isActionOnParent(String action) {
+        return action.contains("parent:");
+    }
+
+    private static String extractAction(String actionOnParent) {
+        return actionOnParent.replace("parent:", "");
     }
 }


### PR DESCRIPTION
## Motivation

While introducing Jetpack compose in our android project, we noticed that Calabash is not able to identify Compose UI components. We also found out that `UIAutomator` is able to "see" elements in the UI but it is very difficult to interact with them because there are no identifiers available (Compose tests in espresso use `testTag` but it is not visible for `UIAutomator`). The only option we have is to use text and content description to identify components so we are able to interact with them.

Some Compose components are identified by `UIAutomator` as multiple nodes and this prevents us from properly interacting with them. For example, for the following `CheckBox` component (notice it is implemented following [compose accessibility guidelines](https://developer.android.com/jetpack/compose/accessibility) )

```kotlin
    Column(modifier) {
        val (isChecked, setIsChecked) = remember { mutableStateOf(false) }
        Row(
            modifier = Modifier
                .toggleable(
                    value = isChecked,
                    onValueChange = { setIsChecked(!isChecked) },
                    role = Checkbox
                )
                .padding(end = 16.dp)
        ) {
            Checkbox(
                checked = isChecked,
                onCheckedChange = null
            )
            Text(
                text = "I accept the terms and conditions.",
                modifier = Modifier
                    .padding(horizontal = 8.dp)
                    .fillMaxWidth()
            )
        }
    }
```
Would have the following output from `perform_action('uiautomator_ui_dump')`

```xml
<node bounds="[42,1202][1038,1328]" checkable="true" checked="false" class="android.view.View"
    clickable="true" content-desc="" enabled="true" focusable="true"
    focused="false" index="8" long-clickable="false" package="com.xing.android" password="false"
    resource-id="" scrollable="false" selected="false" text=""
    visible-to-user="true">
    <node bounds="[126,1234][975,1287]" checkable="false" checked="false"
        class="android.view.View" clickable="false" content-desc=""
        enabled="true" focusable="false" focused="false" index="0"
        long-clickable="false" package="com.xing.android" password="false" resource-id=""
        scrollable="false" selected="false" text="I accept the terms and conditions."
        visible-to-user="true" />
    <node bounds="[42,1234][1038,1297]" checkable="false" checked="false" class="android.widget.CheckBox"
        clickable="false" content-desc="" enabled="true" focusable="false"
        focused="false" index="1" long-clickable="false" package="com.xing.android"
        password="false" resource-id="" scrollable="false" selected="false"
        text="" visible-to-user="true" />
</node>
```

As you can see, the`CheckBox` is represented by three nodes: a parent node that is `checkable` and two child nodes: one containing the text and one containing the`CheckBox` icon (both of them not `checkable`). As we can only use text to identify components, in this case we would use the following to try to get information about the check status of the `CheckBox`:

`perform_action('uiautomator_execute', 'text', 'I accept the terms and conditions.', 0, 'isChecked')`

    Note: documentation about the command:
    `perform_action('uiautomator_execute', 'strategy', 'locator', element index, 'action')` 

This command will always return `false` because the node located is the first child and it is not `checkable`. Information about the check status is only in its parent.

## Proposed solution

Allow Calabash to execute `UIAutomator`actions on the parent of the located node.

Proposed syntax:
* To execute actions on the found node (keeps as is):
    `perform_action('uiautomator_execute', 'strategy', 'locator', element index, 'action')` 

* To execute actions on the parent of the found node:
    `perform_action('uiautomator_execute', 'strategy', 'locator', element index, 'parent:action')` 

 Examples: 
`perform_action('uiautomator_execute', 'text', 'I accept the terms and conditions.', 0, 'parent:isChecked')`
`perform_action('uiautomator_execute', 'text', 'I accept the terms and conditions.', 0, 'parent:isCheckable')`
`perform_action('uiautomator_execute', 'text', 'I accept the terms and conditions.', 0, 'parent:click')`


Note: if this PR gets merged we will need to update the [documentation about UI automator](https://github.com/calabash/calabash-android/wiki/UIAutomator2)