### PR TITLE
Add action to set text to ui automator

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/Actions.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/Actions.java
@@ -1,5 +1,11 @@
 package sh.calaba.instrumentationbackend.actions.device;
 
+/**
+ * List of UIAutomator actions supported by uiautomator_execute command.
+ *
+ * List of available methods in UIAutomator can be found here:
+ * https://developer.android.com/reference/androidx/test/uiautomator/UiObject2
+ */
 public enum Actions {
     click,
     longClick,

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/StrategyVerifier.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/StrategyVerifier.java
@@ -1,0 +1,18 @@
+package sh.calaba.instrumentationbackend.actions.device;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StrategyVerifier {
+    public static void verifyStrategy(String strategy) {
+        try {
+            Strategies.valueOf(strategy);
+        } catch (IllegalArgumentException e) {
+            List<Strategies> availableStrategies = Arrays.asList(Strategies.values());
+            String errorMessage =
+                  String.format("Unsupported strategy: %s. The list of available strategies is %s", strategy,
+                        availableStrategies);
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
+}

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSetText.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSetText.java
@@ -1,0 +1,78 @@
+package sh.calaba.instrumentationbackend.actions.device;
+
+import android.support.annotation.NonNull;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject2;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.Until;
+import sh.calaba.instrumentationbackend.InstrumentationBackend;
+import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.actions.Action;
+
+import static sh.calaba.instrumentationbackend.actions.device.StrategyVerifier.verifyStrategy;
+
+public class UiautomatorSetText implements Action {
+    @Override
+    public Result execute(String... args) {
+        UiDevice mDevice = InstrumentationBackend.getUiDevice();
+        try {
+            String strategy = args[0];
+            String locator = args[1];
+            int index = Integer.parseInt(args[2]);
+            String text = args[3];
+            boolean executeOnParent = false;
+            if (args.length >= 5) {
+                executeOnParent = Boolean.parseBoolean(args[4]);
+            }
+
+            verifyStrategy(strategy);
+
+            Method strategyMethod = By.class.getMethod(strategy, String.class);
+            BySelector selector = (BySelector) strategyMethod.invoke(By.class, locator);
+
+            List<UiObject2> matchingObjects = mDevice.findObjects(selector);
+            if (matchingObjects.isEmpty()) {
+                String errorMessage = String.format("Found no elements for locator: %s by strategy: %s", locator, strategy);
+                throw new UiObjectNotFoundException(errorMessage);
+            }
+            UiObject2 targetObject = matchingObjects.get(index);
+
+            if (executeOnParent) {
+                return setTextOnObject(targetObject.getParent(), text);
+            } else {
+                return setTextOnObject(targetObject, text);
+            }
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            return new Result(false, e.getMessage());
+        } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException e) {
+            return new Result(false, e.getMessage());
+        } catch (UiObjectNotFoundException e) {
+            return new Result(false, e.getMessage());
+        }
+    }
+
+    private Result setTextOnObject(UiObject2 targetObject, @NonNull String text)
+          throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        targetObject.setText(text);
+        targetObject.wait(Until.textMatches(text), 1000);
+        if (text.equals(targetObject.getText())) {
+            return new Result(true, "Text was set to the view.");
+        } else {
+            return new Result(false,
+                  "It was not possible to set the text to the view, does it have a settable text field?");
+        }
+    }
+
+    @Override
+    public String key() {
+        return "uiautomator_set_text";
+    }
+}

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSetText.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSetText.java
@@ -11,7 +11,6 @@ import androidx.test.uiautomator.BySelector;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
-import androidx.test.uiautomator.Until;
 import sh.calaba.instrumentationbackend.InstrumentationBackend;
 import sh.calaba.instrumentationbackend.Result;
 import sh.calaba.instrumentationbackend.actions.Action;
@@ -62,13 +61,7 @@ public class UiautomatorSetText implements Action {
     private Result setTextOnObject(UiObject2 targetObject, @NonNull String text)
           throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
         targetObject.setText(text);
-        targetObject.wait(Until.textMatches(text), 1000);
-        if (text.equals(targetObject.getText())) {
-            return new Result(true, "Text was set to the view.");
-        } else {
-            return new Result(false,
-                  "It was not possible to set the text to the view, does it have a settable text field?");
-        }
+        return new Result(true, "");
     }
 
     @Override


### PR DESCRIPTION
## Motivation

The action `setText` was not available through `UIAutomator` because it required from a parameter (all actions available don't require a parameter: `click`, `isChecked`, etc.). As with compose we have to rely on `UIAutomator` to interact with the elements on the screen, it was impossible for us to `setText` in an input field from Compose. 

As we explained in https://github.com/calabash/calabash-android-server/pull/110, some Compose components are identified by `UIAutomator` as multiple nodes and this prevents us from properly interacting with them. Here is how `UIAutomator` "sees" the following input field:

<img width="391" alt="image" src="https://user-images.githubusercontent.com/10325350/168614504-4cbb7b2f-fbcc-4f38-bb3d-35c07a237959.png">

```xml
<node bounds="[42,1045][1038,1192]" checkable="false" checked="false" class="android.widget.EditText"
    clickable="true" content-desc="" enabled="true" focusable="true"
    focused="false" index="7" long-clickable="true" package="com.xxxx" password="false"
    resource-id="" scrollable="false" selected="false" text="my.username"
    visible-to-user="true">
    <node bounds="[42,1045][1038,1192]" checkable="false" checked="false" class="android.view.View"
        clickable="false" content-desc="User name text input" enabled="true"
        focusable="false" focused="false" index="0" long-clickable="false"
        package="com.xxx" password="false" resource-id="" scrollable="false"
        selected="false" text="" visible-to-user="true" />
    <node bounds="[84,1067][245,1107]" checkable="false" checked="false" class="android.view.View"
        clickable="false" content-desc="" enabled="true" focusable="false"
        focused="false" index="1" long-clickable="false" package="com.xxxx"
        password="false" resource-id="" scrollable="false" selected="false"
        text="User name" visible-to-user="true" />
</node>
```

We have different options to identify this input field:
- Using its text. `strategy`: 'text' , `locator` : 'my.username' --> It will return the main node where we will be able to set the text
- Using its content description `strategy`: 'desc', `locator`: 'User name text input' --> It will return a child node where we can't set the text. *We have the same issue as we explained in https://github.com/calabash/calabash-android-server/pull/110 : **in some cases we need to execute the method in the parent node**.

## Proposed solution

Add the command `uiautomator_set_text` to allow to set text into an input field with the option to set text in the parent node if required. The command proposed syntax is very similar to the one used to execute actions, we want the command to be as flexible as possible so the developer can decide how to find the node:

 `perform_action('uiautomator_set_text', 'strategy', 'locator', element index, 'text', executeOnParent)` 

Example of use:
* If we can use the text on the input field to identify it we don't need to set the text in the parent:

    `perform_action('uiautomator_set_text', 'text', 'Current text', 0,  'New text')`

* If we use the content description to identify the element we have to set the text in the parent, for that we pass a `true` in the last parameter `executeOnParent`

    `perform_action('uiautomator_set_text', 'desc', 'User name text input', 0, 'Some new text', true)`

Note: this action, would also work for non-compose views. We could find an `EditText` using its class for example: 

`perform_action('uiautomator_set_text', 'clazz', 'android.widget.EditText', 0, 'Some text')`

It wouldn't be reliable in Compose though, because some other elements like the dropdowns are also mapped as `android.widget.EditText` so it might be a problem if your screen has both input fields and dropdown menus because you want to be able to distinguish them by class.


